### PR TITLE
Unambiguous log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ anyhow = {version = "1.0", features = ["backtrace"], optional = true}
 mutex-trait = "0.2"
 embedded-svc = {version = "0.6", git = "https://github.com/ivmarkov/embedded-svc.git"}
 #embedded-svc = {version = "*", path = "../embedded-svc"}
-esp-idf-sys = {version = "0.12", git = "https://github.com/ivmarkov/esp-idf-sys.git"}
+esp-idf-sys = {version = "0.12", path = "../esp-idf-sys"}
 #esp-idf-sys = {version = "*", path = "../esp-idf-sys"}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,19 +5,20 @@
 #[macro_use]
 extern crate alloc;
 
-pub mod sysloop;
+#[cfg(any(feature = "std"))] // TODO: Lower requirements to "alloc"
+pub mod httpd;
+#[cfg(any(feature = "alloc"))]
+// TODO: Ideally should not need "alloc" (also for performance reasons)
+pub mod log;
 pub mod netif;
 #[cfg(any(feature = "alloc"))] // TODO: Expose a subset which does not require "alloc"
 pub mod nvs;
 #[cfg(any(feature = "alloc"))] // TODO: Expose a subset which does not require "alloc"
 pub mod nvs_storage;
+pub mod ping;
+pub mod sysloop;
 #[cfg(any(feature = "alloc"))] // TODO: Expose a subset which does not require "alloc"
 pub mod wifi;
-pub mod ping;
-#[cfg(any(feature = "std"))] // TODO: Lower requirements to "alloc"
-pub mod httpd;
-#[cfg(any(feature = "alloc"))] // TODO: Ideally should not need "alloc" (also for performance reasons)
-pub mod log;
 
 #[cfg(any(feature = "binstart", feature = "libstart"))]
 pub mod start;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,4 +1,4 @@
-use log::{Level, LevelFilter, Metadata, Record};
+use ::log::{Level, LevelFilter, Metadata, Record};
 
 use esp_idf_sys::*;
 
@@ -20,7 +20,7 @@ impl From<Newtype<esp_log_level_t>> for LevelFilter {
             esp_log_level_t_ESP_LOG_INFO => LevelFilter::Info,
             esp_log_level_t_ESP_LOG_DEBUG => LevelFilter::Debug,
             esp_log_level_t_ESP_LOG_VERBOSE => LevelFilter::Trace,
-            _ => LevelFilter::Trace
+            _ => LevelFilter::Trace,
         }
     }
 }
@@ -33,7 +33,7 @@ impl From<LevelFilter> for Newtype<esp_log_level_t> {
             LevelFilter::Warn => esp_log_level_t_ESP_LOG_WARN,
             LevelFilter::Info => esp_log_level_t_ESP_LOG_INFO,
             LevelFilter::Debug => esp_log_level_t_ESP_LOG_DEBUG,
-            LevelFilter::Trace => esp_log_level_t_ESP_LOG_VERBOSE
+            LevelFilter::Trace => esp_log_level_t_ESP_LOG_VERBOSE,
         })
     }
 }
@@ -47,7 +47,7 @@ impl From<Newtype<esp_log_level_t>> for Level {
             esp_log_level_t_ESP_LOG_INFO => Level::Info,
             esp_log_level_t_ESP_LOG_DEBUG => Level::Debug,
             esp_log_level_t_ESP_LOG_VERBOSE => Level::Trace,
-            _ => Level::Trace
+            _ => Level::Trace,
         }
     }
 }
@@ -59,7 +59,7 @@ impl From<Level> for Newtype<esp_log_level_t> {
             Level::Warn => esp_log_level_t_ESP_LOG_WARN,
             Level::Info => esp_log_level_t_ESP_LOG_INFO,
             Level::Debug => esp_log_level_t_ESP_LOG_DEBUG,
-            Level::Trace => esp_log_level_t_ESP_LOG_VERBOSE
+            Level::Trace => esp_log_level_t_ESP_LOG_VERBOSE,
         })
     }
 }
@@ -76,7 +76,12 @@ impl Logger {
     pub fn set_target_level(&self, target: impl AsRef<str>, level_filter: LevelFilter) {
         let ctarget = CString::new(target.as_ref()).unwrap();
 
-        unsafe {esp_log_level_set(ctarget.as_c_str().as_ptr(), Newtype::<esp_log_level_t>::from(level_filter).0)};
+        unsafe {
+            esp_log_level_set(
+                ctarget.as_c_str().as_ptr(),
+                Newtype::<esp_log_level_t>::from(level_filter).0,
+            )
+        };
     }
 
     fn get_marker(level: Level) -> &'static CStr {
@@ -85,8 +90,9 @@ impl Logger {
             Level::Warn => b"W\0",
             Level::Info => b"I\0",
             Level::Debug => b"D\0",
-            Level::Trace => b"V\0"
-        }).unwrap()
+            Level::Trace => b"V\0",
+        })
+        .unwrap()
     }
 
     fn get_color(level: Level) -> Option<u8> {
@@ -94,10 +100,10 @@ impl Logger {
             None
         } else {
             match level {
-                Level::Error => Some(31),  // LOG_COLOR_RED
-                Level::Warn => Some(33),   // LOG_COLOR_BROWN
-                Level::Info => Some(32),   // LOG_COLOR_GREEN,
-                _ => None
+                Level::Error => Some(31), // LOG_COLOR_RED
+                Level::Warn => Some(33),  // LOG_COLOR_BROWN
+                Level::Info => Some(32),  // LOG_COLOR_GREEN,
+                _ => None,
             }
         }
     }
@@ -127,7 +133,8 @@ impl log::Log for Logger {
                         Self::get_marker(record.metadata().level()).as_ptr(),
                         esp_log_timestamp(),
                         ctarget.as_c_str().as_ptr(),
-                        coutput.as_c_str().as_ptr());
+                        coutput.as_c_str().as_ptr(),
+                    );
                 }
             } else {
                 unsafe {
@@ -138,7 +145,8 @@ impl log::Log for Logger {
                         Self::get_marker(record.metadata().level()).as_ptr(),
                         esp_log_timestamp(),
                         ctarget.as_c_str().as_ptr(),
-                        coutput.as_c_str().as_ptr());
+                        coutput.as_c_str().as_ptr(),
+                    );
                 }
             }
         }

--- a/src/log.rs
+++ b/src/log.rs
@@ -66,7 +66,7 @@ impl From<Level> for Newtype<esp_log_level_t> {
 
 impl Logger {
     pub fn initialize(&self) {
-        log::set_max_level(self.get_max_level());
+        ::log::set_max_level(self.get_max_level());
     }
 
     pub fn get_max_level(&self) -> LevelFilter {
@@ -109,7 +109,7 @@ impl Logger {
     }
 }
 
-impl log::Log for Logger {
+impl ::log::Log for Logger {
     fn enabled(&self, metadata: &Metadata) -> bool {
         metadata.level() <= LevelFilter::from(Newtype(CONFIG_LOG_DEFAULT_LEVEL))
     }

--- a/src/netif.rs
+++ b/src/netif.rs
@@ -1,4 +1,4 @@
-use log::*;
+use ::log::*;
 
 use esp_idf_sys::*;
 
@@ -15,7 +15,7 @@ pub struct EspNetif(PrivateData);
 impl EspNetif {
     pub fn new() -> Result<Self, EspError> {
         unsafe {
-            TAKEN.lock(|taken|
+            TAKEN.lock(|taken| {
                 if taken.0 {
                     Err(EspError::from(ESP_ERR_INVALID_STATE as i32).unwrap())
                 } else {
@@ -26,7 +26,7 @@ impl EspNetif {
                     *taken = (true, true);
                     Ok(EspNetif(PrivateData))
                 }
-            )
+            })
         }
     }
 }

--- a/src/nvs.rs
+++ b/src/nvs.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
 
-use log::*;
+use ::log::*;
 
 use mutex_trait::*;
 

--- a/src/nvs.rs
+++ b/src/nvs.rs
@@ -9,7 +9,8 @@ use esp_idf_sys::*;
 use crate::private::cstr::*;
 
 static mut DEFAULT_TAKEN: EspMutex<bool> = EspMutex::new(false);
-static mut NONDEFAULT_LOCKED: EspMutex<alloc::collections::BTreeSet<CString>> = EspMutex::new(alloc::collections::BTreeSet::new());
+static mut NONDEFAULT_LOCKED: EspMutex<alloc::collections::BTreeSet<CString>> =
+    EspMutex::new(alloc::collections::BTreeSet::new());
 
 #[derive(Debug)]
 struct PrivateData;
@@ -20,7 +21,7 @@ pub struct EspDefaultNvs(PrivateData);
 impl EspDefaultNvs {
     pub fn new() -> Result<Self, EspError> {
         unsafe {
-            DEFAULT_TAKEN.lock(|taken|
+            DEFAULT_TAKEN.lock(|taken| {
                 if *taken {
                     Err(EspError::from(ESP_ERR_INVALID_STATE as i32).unwrap())
                 } else {
@@ -29,7 +30,7 @@ impl EspDefaultNvs {
                     *taken = true;
                     Ok(default_nvs)
                 }
-            )
+            })
         }
     }
 
@@ -39,8 +40,8 @@ impl EspDefaultNvs {
                 ESP_ERR_NVS_NO_FREE_PAGES | ESP_ERR_NVS_NEW_VERSION_FOUND => {
                     esp!(nvs_flash_erase())?;
                     esp!(nvs_flash_init())?;
-                },
-                _ => ()
+                }
+                _ => (),
             }
         }
 
@@ -66,12 +67,13 @@ pub struct EspNvs(pub(crate) CString);
 
 impl EspNvs {
     pub fn new(partition: impl AsRef<str>) -> Result<Self, EspError> {
-        unsafe {
-            NONDEFAULT_LOCKED.lock(|registrations| Self::init(partition, registrations))
-        }
+        unsafe { NONDEFAULT_LOCKED.lock(|registrations| Self::init(partition, registrations)) }
     }
 
-    fn init(partition: impl AsRef<str>, registrations: &mut alloc::collections::BTreeSet<CString>) -> Result<Self, EspError> {
+    fn init(
+        partition: impl AsRef<str>,
+        registrations: &mut alloc::collections::BTreeSet<CString>,
+    ) -> Result<Self, EspError> {
         let c_partition = CString::new(partition.as_ref()).unwrap();
 
         if registrations.contains(c_partition.as_ref()) {
@@ -84,8 +86,8 @@ impl EspNvs {
                     ESP_ERR_NVS_NO_FREE_PAGES | ESP_ERR_NVS_NEW_VERSION_FOUND => {
                         esp!(nvs_flash_erase_partition(c_partition.as_ptr()))?;
                         esp!(nvs_flash_init_partition(c_partition.as_ptr()))?;
-                    },
-                    _ => ()
+                    }
+                    _ => (),
                 }
             }
         }

--- a/src/nvs_storage.rs
+++ b/src/nvs_storage.rs
@@ -1,8 +1,8 @@
 use core::{any::Any, ptr};
 
 extern crate alloc;
-use alloc::vec;
 use alloc::sync::Arc;
+use alloc::vec;
 
 use embedded_svc::storage::Storage;
 
@@ -15,27 +15,49 @@ use crate::private::cstr::*;
 pub struct EspNvsStorage(Arc<dyn Any>, nvs_handle_t);
 
 impl EspNvsStorage {
-    pub fn new_default(default_nvs: Arc<EspDefaultNvs>, namespace: impl AsRef<str>, read_write: bool) -> Result<Self, EspError> {
+    pub fn new_default(
+        default_nvs: Arc<EspDefaultNvs>,
+        namespace: impl AsRef<str>,
+        read_write: bool,
+    ) -> Result<Self, EspError> {
         let c_namespace = CString::new(namespace.as_ref()).unwrap();
 
         let mut handle: nvs_handle_t = 0;
-        esp!(unsafe {nvs_open(
-            c_namespace.as_ptr(),
-            if read_write {nvs_open_mode_t_NVS_READWRITE} else {nvs_open_mode_t_NVS_READONLY},
-            &mut handle as *mut _)})?;
+        esp!(unsafe {
+            nvs_open(
+                c_namespace.as_ptr(),
+                if read_write {
+                    nvs_open_mode_t_NVS_READWRITE
+                } else {
+                    nvs_open_mode_t_NVS_READONLY
+                },
+                &mut handle as *mut _,
+            )
+        })?;
 
         Ok(Self(default_nvs, handle))
     }
 
-    pub fn new(nvs: Arc<EspNvs>, namespace: impl AsRef<str>, read_write: bool) -> Result<Self, EspError> {
+    pub fn new(
+        nvs: Arc<EspNvs>,
+        namespace: impl AsRef<str>,
+        read_write: bool,
+    ) -> Result<Self, EspError> {
         let c_namespace = CString::new(namespace.as_ref()).unwrap();
 
         let mut handle: nvs_handle_t = 0;
-        esp!(unsafe {nvs_open_from_partition(
-            nvs.0.as_ptr(),
-            c_namespace.as_ptr(),
-            if read_write {nvs_open_mode_t_NVS_READWRITE} else {nvs_open_mode_t_NVS_READONLY},
-            &mut handle as *mut _)})?;
+        esp!(unsafe {
+            nvs_open_from_partition(
+                nvs.0.as_ptr(),
+                c_namespace.as_ptr(),
+                if read_write {
+                    nvs_open_mode_t_NVS_READWRITE
+                } else {
+                    nvs_open_mode_t_NVS_READONLY
+                },
+                &mut handle as *mut _,
+            )
+        })?;
 
         Ok(Self(nvs, handle))
     }
@@ -43,7 +65,9 @@ impl EspNvsStorage {
 
 impl Drop for EspNvsStorage {
     fn drop(&mut self) {
-        unsafe {nvs_close(self.1);}
+        unsafe {
+            nvs_close(self.1);
+        }
     }
 }
 
@@ -55,7 +79,7 @@ impl Storage for EspNvsStorage {
 
         let dummy: u_int64_t = 0;
 
-        match unsafe {nvs_get_u64(self.1, c_key.as_ptr(), dummy as *mut _)} as u32 {
+        match unsafe { nvs_get_u64(self.1, c_key.as_ptr(), dummy as *mut _) } as u32 {
             ESP_ERR_NVS_NOT_FOUND => Ok(false),
             ESP_ERR_NVS_INVALID_LENGTH => Ok(true),
             result => {
@@ -68,13 +92,13 @@ impl Storage for EspNvsStorage {
     fn remove(&mut self, key: impl AsRef<str>) -> Result<bool, Self::Error> {
         let c_key = CString::new(key.as_ref()).unwrap();
 
-        let result = unsafe {nvs_erase_key(self.1, c_key.as_ptr())};
+        let result = unsafe { nvs_erase_key(self.1, c_key.as_ptr()) };
 
         if result == ESP_ERR_NVS_NOT_FOUND as i32 {
             Ok(false)
         } else {
             esp!(result)?;
-            esp!(unsafe {nvs_commit(self.1)})?;
+            esp!(unsafe { nvs_commit(self.1) })?;
 
             Ok(true)
         }
@@ -85,20 +109,29 @@ impl Storage for EspNvsStorage {
 
         let mut value: u_int64_t = 0;
 
-        match unsafe {nvs_get_u64(self.1, c_key.as_ptr(), value as *mut _)} as u32 {
+        match unsafe { nvs_get_u64(self.1, c_key.as_ptr(), value as *mut _) } as u32 {
             ESP_ERR_NVS_NOT_FOUND => Ok(None),
             ESP_ERR_NVS_INVALID_LENGTH => {
                 let mut len: size_t = 0;
 
-                esp!(unsafe {nvs_get_blob(self.1, c_key.as_ptr(), ptr::null_mut(), &mut len as *mut _)})?;
+                esp!(unsafe {
+                    nvs_get_blob(self.1, c_key.as_ptr(), ptr::null_mut(), &mut len as *mut _)
+                })?;
 
                 let mut vec: vec::Vec<u8> = vec::Vec::with_capacity(len as usize);
-                esp!(unsafe {nvs_get_blob(self.1, c_key.as_ptr(), vec.as_mut_ptr() as *mut _, &mut len as *mut _)})?;
+                esp!(unsafe {
+                    nvs_get_blob(
+                        self.1,
+                        c_key.as_ptr(),
+                        vec.as_mut_ptr() as *mut _,
+                        &mut len as *mut _,
+                    )
+                })?;
 
-                unsafe {vec.set_len(len as usize)};
+                unsafe { vec.set_len(len as usize) };
 
                 Ok(Some(vec))
-            },
+            }
             result => {
                 esp!(result)?;
 
@@ -112,7 +145,7 @@ impl Storage for EspNvsStorage {
                     ((value >> 24) & 0xff) as u8,
                     ((value >> 32) & 0xff) as u8,
                     ((value >> 48) & 0xff) as u8,
-                    ((value >> 56) & 0xff) as u8
+                    ((value >> 56) & 0xff) as u8,
                 ];
 
                 Ok(Some(array[..len as usize].to_vec()))
@@ -120,24 +153,38 @@ impl Storage for EspNvsStorage {
         }
     }
 
-    fn put_raw(&mut self, key: impl AsRef<str>, value: impl Into<vec::Vec<u8>>) -> Result<bool, Self::Error> {
+    fn put_raw(
+        &mut self,
+        key: impl AsRef<str>,
+        value: impl Into<vec::Vec<u8>>,
+    ) -> Result<bool, Self::Error> {
         let c_key = CString::new(key.as_ref()).unwrap();
         let mut uvalue: u_int64_t = 0;
 
         let small: bool;
         let found: bool;
 
-        match unsafe {nvs_get_u64(self.1, c_key.as_ptr(), uvalue as *mut _) as u32} {
-            ESP_ERR_NVS_NOT_FOUND => {found = false; small = false;},
-            ESP_ERR_NVS_INVALID_LENGTH => {found = true; small = false;},
-            result => {esp!(result)?; found = true; small = true;}
+        match unsafe { nvs_get_u64(self.1, c_key.as_ptr(), uvalue as *mut _) as u32 } {
+            ESP_ERR_NVS_NOT_FOUND => {
+                found = false;
+                small = false;
+            }
+            ESP_ERR_NVS_INVALID_LENGTH => {
+                found = true;
+                small = false;
+            }
+            result => {
+                esp!(result)?;
+                found = true;
+                small = true;
+            }
         }
 
         let mut value = value.into();
         let new_small = value.len() < 8;
 
         if found && small != new_small {
-            esp!(unsafe {nvs_erase_key(self.1, c_key.as_ptr())})?;
+            esp!(unsafe { nvs_erase_key(self.1, c_key.as_ptr()) })?;
         }
 
         if new_small {
@@ -149,12 +196,19 @@ impl Storage for EspNvsStorage {
             uvalue <<= 8;
             uvalue = uvalue | value.len() as u_int64_t;
 
-            esp!(unsafe {nvs_set_u64(self.1, c_key.as_ptr(), uvalue)})?;
+            esp!(unsafe { nvs_set_u64(self.1, c_key.as_ptr(), uvalue) })?;
         } else {
-            esp!(unsafe {nvs_set_blob(self.1, c_key.as_ptr(), value.as_mut_ptr() as *mut _, value.len() as u32)})?;
+            esp!(unsafe {
+                nvs_set_blob(
+                    self.1,
+                    c_key.as_ptr(),
+                    value.as_mut_ptr() as *mut _,
+                    value.len() as u32,
+                )
+            })?;
         }
 
-        esp!(unsafe {nvs_commit(self.1)})?;
+        esp!(unsafe { nvs_commit(self.1) })?;
 
         Ok(found)
     }

--- a/src/private/edge_config.rs
+++ b/src/private/edge_config.rs
@@ -2,30 +2,37 @@
 mod test {
     use std::{any::Any, borrow::Borrow, sync::Arc};
 
-    use embedded_svc::{edge_config::wifi, httpd::{StateMap, app, registry::Registry, sessions}, wifi::{Configuration, Wifi}};
+    use embedded_svc::{
+        edge_config::wifi,
+        httpd::{app, registry::Registry, sessions, StateMap},
+        wifi::{Configuration, Wifi},
+    };
 
-    use crate::{httpd::ServerRegistry, netif::EspNetif, nvs::EspDefaultNvs, sysloop::EspSysLoop, wifi::EspWifi};
-
+    use crate::{
+        httpd::ServerRegistry, netif::EspNetif, nvs::EspDefaultNvs, sysloop::EspSysLoop,
+        wifi::EspWifi,
+    };
 
     #[test]
     pub fn test() -> anyhow::Result<()> {
         let mut wifi = EspWifi::new(
             Arc::new(EspNetif::new()?),
             Arc::new(EspSysLoop::new()?),
-            Arc::new(EspDefaultNvs::new()?))?;
+            Arc::new(EspDefaultNvs::new()?),
+        )?;
 
         wifi.set_configuration(&Configuration::AccessPoint(Default::default()))?;
 
         let boxed: Box<dyn Any> = Box::new(wifi);
 
-        let app: StateMap = vec![("wifi".to_string(), boxed)]
-            .into_iter()
-            .collect();
+        let app: StateMap = vec![("wifi".to_string(), boxed)].into_iter().collect();
 
         let _server = ServerRegistry::new()
             .register(|registry| wifi::register(registry, "/api", None))?
-            .at("").middleware(sessions::middleware(Default::default()))?
-            .at("").middleware(app::middleware(app))?
+            .at("")
+            .middleware(sessions::middleware(Default::default()))?
+            .at("")
+            .middleware(app::middleware(app))?
             .start(&Default::default())?;
 
         Ok(())

--- a/src/private/mod.rs
+++ b/src/private/mod.rs
@@ -1,6 +1,6 @@
 pub mod common;
-pub mod net;
 pub mod cstr;
+pub mod net;
 
 mod stubs;
 

--- a/src/private/net.rs
+++ b/src/private/net.rs
@@ -10,7 +10,10 @@ impl From<ipv4::Ipv4Addr> for Newtype<esp_ip4_addr_t> {
         let octets = ip.octets();
 
         Newtype(esp_ip4_addr_t {
-            addr: ((octets[3] as u32 & 0xff) << 24) | ((octets[2] as u32 & 0xff) << 16) | ((octets[1] as u32 & 0xff) << 8) | (octets[0] as u32 & 0xff)
+            addr: ((octets[3] as u32 & 0xff) << 24)
+                | ((octets[2] as u32 & 0xff) << 16)
+                | ((octets[1] as u32 & 0xff) << 8)
+                | (octets[0] as u32 & 0xff),
         })
     }
 }
@@ -21,7 +24,8 @@ impl From<Newtype<esp_ip4_addr_t>> for ipv4::Ipv4Addr {
             ((ip.0.addr >> 24) & 0xff) as u8,
             ((ip.0.addr >> 16) & 0xff) as u8,
             ((ip.0.addr >> 8) & 0xff) as u8,
-            (ip.0.addr & 0xff) as u8);
+            (ip.0.addr & 0xff) as u8,
+        );
 
         ipv4::Ipv4Addr::new(a, b, c, d)
     }
@@ -32,16 +36,14 @@ impl From<ipv4::Ipv4Addr> for Newtype<ip4_addr_t> {
         let result: Newtype<esp_ip4_addr_t> = ip.into();
 
         Newtype(ip4_addr_t {
-            addr: result.0.addr
+            addr: result.0.addr,
         })
     }
 }
 
 impl From<Newtype<ip4_addr_t>> for ipv4::Ipv4Addr {
     fn from(ip: Newtype<ip4_addr_t>) -> Self {
-        Newtype(esp_ip4_addr_t{
-            addr: ip.0.addr
-        }).into()
+        Newtype(esp_ip4_addr_t { addr: ip.0.addr }).into()
     }
 }
 
@@ -59,7 +61,8 @@ impl TryFrom<Newtype<esp_ip4_addr_t>> for Mask {
     fn try_from(esp_ip: Newtype<esp_ip4_addr_t>) -> Result<Self, Self::Error> {
         let ip: ipv4::Ipv4Addr = esp_ip.into();
 
-        ip.try_into().map_err(|_| EspError::from(ESP_ERR_INVALID_ARG as i32).unwrap())
+        ip.try_into()
+            .map_err(|_| EspError::from(ESP_ERR_INVALID_ARG as i32).unwrap())
     }
 }
 
@@ -77,6 +80,7 @@ impl TryFrom<Newtype<ip4_addr_t>> for Mask {
     fn try_from(esp_ip: Newtype<ip4_addr_t>) -> Result<Self, Self::Error> {
         let ip: ipv4::Ipv4Addr = esp_ip.into();
 
-        ip.try_into().map_err(|_| EspError::from(ESP_ERR_INVALID_ARG as i32).unwrap())
+        ip.try_into()
+            .map_err(|_| EspError::from(ESP_ERR_INVALID_ARG as i32).unwrap())
     }
 }

--- a/src/private/stubs.rs
+++ b/src/private/stubs.rs
@@ -2,7 +2,7 @@ use esp_idf_sys::c_types;
 
 // TODO: Figure out which library references this
 #[no_mangle]
-pub extern fn timegm(_: c_types::c_void) -> c_types::c_int {
+pub extern "C" fn timegm(_: c_types::c_void) -> c_types::c_int {
     // Not supported but don't crash just in case
     0
 }

--- a/src/start.rs
+++ b/src/start.rs
@@ -36,13 +36,15 @@ extern "Rust" {
 
 #[no_mangle]
 pub extern "C" fn app_main() {
-    log::set_logger(&LOGGER).map(|()| LOGGER.initialize()).unwrap();
+    log::set_logger(&LOGGER)
+        .map(|()| LOGGER.initialize())
+        .unwrap();
 
     #[cfg(feature = "binstart")]
     {
-        match unsafe {main(0, core::ptr::null())} {
+        match unsafe { main(0, core::ptr::null()) } {
             0 => log::error!("Unexpected program exit!\n(no error reported)"),
-            n => log::error!("Unexpected program exit!\n{}", n)
+            n => log::error!("Unexpected program exit!\n{}", n),
         }
 
         log::warn!("Will restart now...");
@@ -50,5 +52,7 @@ pub extern "C" fn app_main() {
     }
 
     #[cfg(feature = "libstart")]
-    unsafe {main()}
+    unsafe {
+        main()
+    }
 }

--- a/src/sysloop.rs
+++ b/src/sysloop.rs
@@ -1,4 +1,4 @@
-use log::*;
+use ::log::*;
 
 use mutex_trait::*;
 
@@ -15,7 +15,7 @@ pub struct EspSysLoop(PrivateData);
 impl EspSysLoop {
     pub fn new() -> Result<Self, EspError> {
         unsafe {
-            TAKEN.lock(|taken|
+            TAKEN.lock(|taken| {
                 if *taken {
                     Err(EspError::from(ESP_ERR_INVALID_STATE as i32).unwrap())
                 } else {
@@ -24,7 +24,7 @@ impl EspSysLoop {
                     *taken = true;
                     Ok(EspSysLoop(PrivateData))
                 }
-            )
+            })
         }
     }
 }

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1,23 +1,23 @@
-use core::{cmp, mem, ptr, convert::TryInto, time::Duration};
+use core::{cmp, convert::TryInto, mem, ptr, time::Duration};
 
 extern crate alloc;
-use alloc::vec;
 use alloc::sync::Arc;
+use alloc::vec;
 
+use ::log::*;
 use enumset::*;
-use log::*;
 
 use mutex_trait::*;
 
-use embedded_svc::wifi::*;
 use embedded_svc::ipv4;
+use embedded_svc::wifi::*;
 
 use esp_idf_sys::mutex::RwLock;
 use esp_idf_sys::*;
 
 use crate::netif::EspNetif;
-use crate::sysloop::EspSysLoop;
 use crate::nvs::EspDefaultNvs;
+use crate::sysloop::EspSysLoop;
 
 use crate::private::common::*;
 use crate::private::cstr::*;
@@ -45,7 +45,7 @@ impl From<Newtype<wifi_auth_mode_t>> for AuthMethod {
             wifi_auth_mode_t_WIFI_AUTH_WPA_PSK => AuthMethod::WPA,
             wifi_auth_mode_t_WIFI_AUTH_WPA2_PSK => AuthMethod::WPA2Personal,
             wifi_auth_mode_t_WIFI_AUTH_WPA3_PSK => AuthMethod::WPA3Personal,
-            _ => panic!()
+            _ => panic!(),
         }
     }
 }
@@ -71,8 +71,14 @@ impl From<&ClientConfiguration> for Newtype<wifi_sta_config_t> {
             channel: 0,
             listen_interval: 0,
             sort_method: wifi_sort_method_t_WIFI_CONNECT_AP_BY_SIGNAL,
-            threshold: wifi_scan_threshold_t {rssi: 127, authmode: Newtype::<wifi_auth_mode_t>::from(conf.auth_method).0},
-            pmf_cfg: wifi_pmf_config_t {capable: false, required: false},
+            threshold: wifi_scan_threshold_t {
+                rssi: 127,
+                authmode: Newtype::<wifi_auth_mode_t>::from(conf.auth_method).0,
+            },
+            pmf_cfg: wifi_pmf_config_t {
+                capable: false,
+                required: false,
+            },
         };
 
         set_str(&mut result.ssid, conf.ssid.as_str());
@@ -86,7 +92,11 @@ impl From<&Newtype<wifi_sta_config_t>> for ClientConfiguration {
     fn from(conf: &Newtype<wifi_sta_config_t>) -> Self {
         ClientConfiguration {
             ssid: from_cstr(&conf.0.ssid),
-            bssid: if conf.0.bssid_set {Some(conf.0.bssid)} else {None},
+            bssid: if conf.0.bssid_set {
+                Some(conf.0.bssid)
+            } else {
+                None
+            },
             auth_method: Newtype(conf.0.threshold.authmode).into(),
             password: from_cstr(&conf.0.password),
             ip_conf: None, // This must be set at a later stage
@@ -102,7 +112,7 @@ impl From<&AccessPointConfiguration> for Newtype<wifi_ap_config_t> {
             ssid_len: conf.ssid.len() as u8,
             channel: conf.channel,
             authmode: Newtype::<wifi_auth_mode_t>::from(conf.auth_method).0,
-            ssid_hidden: if conf.ssid_hidden {1} else {0},
+            ssid_hidden: if conf.ssid_hidden { 1 } else { 0 },
             max_connection: cmp::max(conf.max_connections, 16) as u8,
             beacon_interval: 100,
         };
@@ -143,7 +153,7 @@ impl From<Newtype<&wifi_ap_record_t>> for AccessPointInfo {
                 wifi_second_chan_t_WIFI_SECOND_CHAN_NONE => SecondaryChannel::None,
                 wifi_second_chan_t_WIFI_SECOND_CHAN_ABOVE => SecondaryChannel::Above,
                 wifi_second_chan_t_WIFI_SECOND_CHAN_BELOW => SecondaryChannel::Below,
-                _ => panic!()
+                _ => panic!(),
             },
             signal_strength: a.rssi as u8,
             protocols: EnumSet::<Protocol>::empty(), // TODO
@@ -159,7 +169,7 @@ struct Shared {
     router_ip_conf: Option<ipv4::RouterConfiguration>,
 
     status: Status,
-    operating: bool
+    operating: bool,
 }
 
 impl Default for Shared {
@@ -168,7 +178,7 @@ impl Default for Shared {
             client_ip_conf: None,
             router_ip_conf: None,
             status: Status(ClientStatus::Stopped, ApStatus::Stopped),
-            operating: false
+            operating: false,
         }
     }
 }
@@ -189,9 +199,13 @@ pub struct EspWifi {
 }
 
 impl EspWifi {
-    pub fn new(netif: Arc<EspNetif>, sys_loop: Arc<EspSysLoop>, nvs: Arc<EspDefaultNvs>) -> Result<EspWifi, EspError> {
+    pub fn new(
+        netif: Arc<EspNetif>,
+        sys_loop: Arc<EspSysLoop>,
+        nvs: Arc<EspDefaultNvs>,
+    ) -> Result<EspWifi, EspError> {
         unsafe {
-            TAKEN.lock(|taken|
+            TAKEN.lock(|taken| {
                 if *taken {
                     Err(EspError::from(ESP_ERR_INVALID_STATE as i32).unwrap())
                 } else {
@@ -200,11 +214,15 @@ impl EspWifi {
                     *taken = true;
                     Ok(wifi)
                 }
-            )
+            })
         }
     }
 
-    fn init(netif: Arc<EspNetif>, sys_loop: Arc<EspSysLoop>, nvs: Arc<EspDefaultNvs>) -> Result<EspWifi, EspError> {
+    fn init(
+        netif: Arc<EspNetif>,
+        sys_loop: Arc<EspSysLoop>,
+        nvs: Arc<EspDefaultNvs>,
+    ) -> Result<EspWifi, EspError> {
         let mut wifi = EspWifi {
             _netif: netif,
             _sys_loop: sys_loop,
@@ -247,8 +265,18 @@ impl EspWifi {
 
             let shared_ref: *mut _ = &mut *wifi.shared;
 
-            esp!(esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, Option::Some(EspWifi::event_handler), shared_ref as *mut c_types::c_void))?;
-            esp!(esp_event_handler_register(IP_EVENT, ip_event_t_IP_EVENT_STA_GOT_IP as i32, Option::Some(EspWifi::event_handler), shared_ref as *mut c_types::c_void))?;
+            esp!(esp_event_handler_register(
+                WIFI_EVENT,
+                ESP_EVENT_ANY_ID,
+                Option::Some(EspWifi::event_handler),
+                shared_ref as *mut c_types::c_void
+            ))?;
+            esp!(esp_event_handler_register(
+                IP_EVENT,
+                ip_event_t_IP_EVENT_STA_GOT_IP as i32,
+                Option::Some(EspWifi::event_handler),
+                shared_ref as *mut c_types::c_void
+            ))?;
 
             info!("Event handlers registered");
         }
@@ -268,12 +296,14 @@ impl EspWifi {
 
     fn get_client_conf(&self) -> Result<ClientConfiguration, EspError> {
         let mut wifi_config = [0 as u8; mem::size_of::<wifi_config_t>()];
-        let wifi_config_ref: &mut wifi_config_t = unsafe {mem::transmute(&mut wifi_config)};
+        let wifi_config_ref: &mut wifi_config_t = unsafe { mem::transmute(&mut wifi_config) };
 
-        esp!(unsafe {esp_wifi_get_config(esp_interface_t_ESP_IF_WIFI_STA, wifi_config_ref)})?;
+        esp!(unsafe { esp_wifi_get_config(esp_interface_t_ESP_IF_WIFI_STA, wifi_config_ref) })?;
 
-        let mut result: ClientConfiguration = unsafe {(&Newtype(wifi_config_ref.sta)).into()};
-        result.ip_conf = self.shared.lock_read(|shared| shared.client_ip_conf.clone());
+        let mut result: ClientConfiguration = unsafe { (&Newtype(wifi_config_ref.sta)).into() };
+        result.ip_conf = self
+            .shared
+            .lock_read(|shared| shared.client_ip_conf.clone());
 
         info!("Providing STA configuration: {:?}", &result);
 
@@ -284,10 +314,10 @@ impl EspWifi {
         info!("Setting STA configuration: {:?}", conf);
 
         let mut wifi_config = wifi_config_t {
-            sta: Newtype::<wifi_sta_config_t>::from(conf).0
+            sta: Newtype::<wifi_sta_config_t>::from(conf).0,
         };
 
-        esp!(unsafe {esp_wifi_set_config(esp_interface_t_ESP_IF_WIFI_STA, &mut wifi_config)})?;
+        esp!(unsafe { esp_wifi_set_config(esp_interface_t_ESP_IF_WIFI_STA, &mut wifi_config) })?;
 
         self.set_client_ip_conf(&conf.ip_conf)?;
 
@@ -298,12 +328,14 @@ impl EspWifi {
 
     fn get_ap_conf(&self) -> Result<AccessPointConfiguration, EspError> {
         let mut wifi_config = [0 as u8; mem::size_of::<wifi_config_t>()];
-        let wifi_config_ref: &mut wifi_config_t = unsafe {mem::transmute(&mut wifi_config)};
+        let wifi_config_ref: &mut wifi_config_t = unsafe { mem::transmute(&mut wifi_config) };
 
-        esp!(unsafe {esp_wifi_get_config(esp_interface_t_ESP_IF_WIFI_AP, wifi_config_ref)})?;
+        esp!(unsafe { esp_wifi_get_config(esp_interface_t_ESP_IF_WIFI_AP, wifi_config_ref) })?;
 
-        let mut result: AccessPointConfiguration = unsafe {Newtype(wifi_config_ref.ap).into()};
-        result.ip_conf = self.shared.lock_read(|shared| shared.router_ip_conf.clone());
+        let mut result: AccessPointConfiguration = unsafe { Newtype(wifi_config_ref.ap).into() };
+        result.ip_conf = self
+            .shared
+            .lock_read(|shared| shared.router_ip_conf.clone());
 
         info!("Providing AP configuration: {:?}", &result);
 
@@ -314,10 +346,10 @@ impl EspWifi {
         info!("Setting AP configuration: {:?}", conf);
 
         let mut wifi_config = wifi_config_t {
-            ap: Newtype::<wifi_ap_config_t>::from(conf).0
+            ap: Newtype::<wifi_ap_config_t>::from(conf).0,
         };
 
-        esp!(unsafe{esp_wifi_set_config(esp_interface_t_ESP_IF_WIFI_AP, &mut wifi_config)})?;
+        esp!(unsafe { esp_wifi_set_config(esp_interface_t_ESP_IF_WIFI_AP, &mut wifi_config) })?;
         self.set_router_ip_conf(&conf.ip_conf)?;
 
         info!("AP configuration done");
@@ -325,7 +357,10 @@ impl EspWifi {
         Ok(())
     }
 
-    fn set_client_ip_conf(&mut self, conf: &Option<ipv4::ClientConfiguration>) -> Result<(), EspError> {
+    fn set_client_ip_conf(
+        &mut self,
+        conf: &Option<ipv4::ClientConfiguration>,
+    ) -> Result<(), EspError> {
         unsafe {
             EspWifi::clear_ip_conf(&mut self.sta_netif)?;
             self.sta_netif = ptr::null_mut();
@@ -333,22 +368,27 @@ impl EspWifi {
             if let Some(client_conf) = conf {
                 info!("Setting STA IP configuration: {:?}", client_conf);
 
-                let ip_cfg  = esp_netif_inherent_config_t {
+                let ip_cfg = esp_netif_inherent_config_t {
                     flags: match client_conf {
-                        ipv4::ClientConfiguration::DHCP =>
+                        ipv4::ClientConfiguration::DHCP => {
                             esp_netif_flags_ESP_NETIF_DHCP_CLIENT
-                            | esp_netif_flags_ESP_NETIF_FLAG_GARP
-                            | esp_netif_flags_ESP_NETIF_FLAG_EVENT_IP_MODIFIED,
-                        ipv4::ClientConfiguration::Fixed(_) => esp_netif_flags_ESP_NETIF_FLAG_AUTOUP,
+                                | esp_netif_flags_ESP_NETIF_FLAG_GARP
+                                | esp_netif_flags_ESP_NETIF_FLAG_EVENT_IP_MODIFIED
+                        }
+                        ipv4::ClientConfiguration::Fixed(_) => {
+                            esp_netif_flags_ESP_NETIF_FLAG_AUTOUP
+                        }
                     },
                     mac: [0; 6],
                     ip_info: match client_conf {
                         ipv4::ClientConfiguration::DHCP => ptr::null_mut(),
-                        ipv4::ClientConfiguration::Fixed(ref fixed_conf) => &mut esp_netif_ip_info_t {
-                            ip: Newtype::<esp_ip4_addr_t>::from(fixed_conf.ip).0,
-                            netmask: Newtype::<esp_ip4_addr_t>::from(fixed_conf.subnet.mask).0,
-                            gw: Newtype::<esp_ip4_addr_t>::from(fixed_conf.subnet.gateway).0,
-                        },
+                        ipv4::ClientConfiguration::Fixed(ref fixed_conf) => {
+                            &mut esp_netif_ip_info_t {
+                                ip: Newtype::<esp_ip4_addr_t>::from(fixed_conf.ip).0,
+                                netmask: Newtype::<esp_ip4_addr_t>::from(fixed_conf.subnet.mask).0,
+                                gw: Newtype::<esp_ip4_addr_t>::from(fixed_conf.subnet.gateway).0,
+                            }
+                        }
                     },
                     get_ip_event: match client_conf {
                         ipv4::ClientConfiguration::DHCP => ip_event_t_IP_EVENT_STA_GOT_IP,
@@ -358,7 +398,8 @@ impl EspWifi {
                         ipv4::ClientConfiguration::DHCP => ip_event_t_IP_EVENT_STA_LOST_IP,
                         ipv4::ClientConfiguration::Fixed(_) => 0,
                     },
-                    if_key: CStr::from_ptr("WIFI_STA_DEF\0".as_ptr() as *const c_types::c_char).as_ptr(),
+                    if_key: CStr::from_ptr("WIFI_STA_DEF\0".as_ptr() as *const c_types::c_char)
+                        .as_ptr(),
                     if_desc: CStr::from_ptr("sta".as_ptr() as *const c_types::c_char).as_ptr(),
                     route_prio: 100,
                 };
@@ -381,12 +422,16 @@ impl EspWifi {
             }
         }
 
-        self.shared.lock(|shared| shared.client_ip_conf = conf.clone());
+        self.shared
+            .lock(|shared| shared.client_ip_conf = conf.clone());
 
         Ok(())
     }
 
-    fn set_router_ip_conf(&mut self, conf: &Option<ipv4::RouterConfiguration>) -> Result<(), EspError> {
+    fn set_router_ip_conf(
+        &mut self,
+        conf: &Option<ipv4::RouterConfiguration>,
+    ) -> Result<(), EspError> {
         unsafe {
             EspWifi::clear_ip_conf(&mut self.ap_netif)?;
             self.ap_netif = ptr::null_mut();
@@ -394,8 +439,12 @@ impl EspWifi {
             if let Some(router_conf) = conf {
                 info!("Setting AP IP configuration: {:?}", router_conf);
 
-                let ip_cfg  = esp_netif_inherent_config_t {
-                    flags: (if router_conf.dhcp_enabled {esp_netif_flags_ESP_NETIF_DHCP_SERVER} else {0}) | esp_netif_flags_ESP_NETIF_FLAG_AUTOUP,
+                let ip_cfg = esp_netif_inherent_config_t {
+                    flags: (if router_conf.dhcp_enabled {
+                        esp_netif_flags_ESP_NETIF_DHCP_SERVER
+                    } else {
+                        0
+                    }) | esp_netif_flags_ESP_NETIF_FLAG_AUTOUP,
                     mac: [0; 6],
                     ip_info: &mut esp_netif_ip_info_t {
                         ip: Newtype::<esp_ip4_addr_t>::from(router_conf.subnet.gateway).0,
@@ -404,7 +453,8 @@ impl EspWifi {
                     },
                     get_ip_event: 0,
                     lost_ip_event: 0,
-                    if_key: CStr::from_ptr("WIFI_AP_DEF\0".as_ptr() as *const c_types::c_char).as_ptr(),
+                    if_key: CStr::from_ptr("WIFI_AP_DEF\0".as_ptr() as *const c_types::c_char)
+                        .as_ptr(),
                     if_desc: CStr::from_ptr("ap".as_ptr() as *const c_types::c_char).as_ptr(),
                     route_prio: 10,
                 };
@@ -427,7 +477,8 @@ impl EspWifi {
             }
         }
 
-        self.shared.lock(|shared| shared.router_ip_conf = conf.clone());
+        self.shared
+            .lock(|shared| shared.router_ip_conf = conf.clone());
 
         Ok(())
     }
@@ -439,11 +490,11 @@ impl EspWifi {
             let status = self.get_status();
 
             if waiter(&status) {
-                break status
+                break status;
             }
 
             // TODO: Replace with waiting on a condvar that wakes up when an event is received
-            unsafe {vTaskDelay(100)};
+            unsafe { vTaskDelay(100) };
         };
 
         info!("Waiting for status done - success");
@@ -451,7 +502,11 @@ impl EspWifi {
         result
     }
 
-    fn wait_status_with_timeout<F: Fn(&Status) -> bool>(&self, timeout: Duration, waiter: F) -> Result<(), Status> {
+    fn wait_status_with_timeout<F: Fn(&Status) -> bool>(
+        &self,
+        timeout: Duration,
+        waiter: F,
+    ) -> Result<(), Status> {
         info!("About to wait for status with timeout {:?}", timeout);
 
         let mut accum = Duration::from_millis(0);
@@ -462,17 +517,17 @@ impl EspWifi {
             if waiter(&status) {
                 info!("Waiting for status done - success");
 
-                break Ok(())
+                break Ok(());
             }
 
             if accum > timeout {
                 info!("Timeout while waiting for status");
 
-                break Err(status)
+                break Err(status);
             }
 
             // TODO: Replace with waiting on a condvar that wakes up when an event is received
-            unsafe {vTaskDelay(500)};
+            unsafe { vTaskDelay(500) };
             accum += Duration::from_millis(500);
         }
     }
@@ -488,11 +543,12 @@ impl EspWifi {
         if status.is_operating() {
             info!("Status is of operating type, starting");
 
-            esp!(unsafe {esp_wifi_start()})?;
+            esp!(unsafe { esp_wifi_start() })?;
 
             info!("Start requested");
 
-            let result = self.wait_status_with_timeout(Duration::from_secs(10), |s| !s.is_transitional());
+            let result =
+                self.wait_status_with_timeout(Duration::from_secs(10), |s| !s.is_transitional());
 
             if let Err(_) = result {
                 info!("Timeout while waiting for the requested state");
@@ -513,20 +569,21 @@ impl EspWifi {
 
         self.shared.lock(|shared| shared.operating = false);
 
-        esp!(unsafe {esp_wifi_disconnect()})
-            .or_else(|err| if err.code() == esp_idf_sys::ESP_ERR_WIFI_NOT_STARTED as esp_err_t {
+        esp!(unsafe { esp_wifi_disconnect() }).or_else(|err| {
+            if err.code() == esp_idf_sys::ESP_ERR_WIFI_NOT_STARTED as esp_err_t {
                 Ok(())
             } else {
                 Err(err)
-            })?;
+            }
+        })?;
         info!("Disconnect requested");
 
-        esp!(unsafe {esp_wifi_stop()})?;
+        esp!(unsafe { esp_wifi_stop() })?;
         info!("Stop requested");
 
         self.wait_status(|s| match s {
             Status(ClientStatus::Stopped, ApStatus::Stopped) => true,
-            _ => false
+            _ => false,
         });
 
         info!("Stopped");
@@ -541,8 +598,16 @@ impl EspWifi {
             EspWifi::clear_ip_conf(&mut self.ap_netif)?;
             EspWifi::clear_ip_conf(&mut self.sta_netif)?;
 
-            esp!(esp_event_handler_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, Option::Some(EspWifi::event_handler)))?;
-            esp!(esp_event_handler_unregister(IP_EVENT, ESP_EVENT_ANY_ID as i32, Option::Some(EspWifi::event_handler)))?;
+            esp!(esp_event_handler_unregister(
+                WIFI_EVENT,
+                ESP_EVENT_ANY_ID,
+                Option::Some(EspWifi::event_handler)
+            ))?;
+            esp!(esp_event_handler_unregister(
+                IP_EVENT,
+                ESP_EVENT_ANY_ID as i32,
+                Option::Some(EspWifi::event_handler)
+            ))?;
 
             info!("Event handlers deregistered");
 
@@ -580,17 +645,23 @@ impl EspWifi {
             //         passive: 0,
             //     },
             // };
-            esp!(esp_wifi_scan_start(ptr::null_mut()/*&scan_conf*/, true))?;
+            esp!(esp_wifi_scan_start(
+                ptr::null_mut(), /*&scan_conf*/
+                true
+            ))?;
         }
 
         let mut found_ap: u16 = 0;
-        esp!(unsafe {esp_wifi_scan_get_ap_num(&mut found_ap as *mut _)})?;
+        esp!(unsafe { esp_wifi_scan_get_ap_num(&mut found_ap as *mut _) })?;
 
         Ok(found_ap as usize)
     }
 
     #[allow(non_upper_case_globals)]
-    fn do_get_scan_infos(&mut self, ap_infos_raw: &mut [wifi_ap_record_t]) -> Result<usize, EspError> {
+    fn do_get_scan_infos(
+        &mut self,
+        ap_infos_raw: &mut [wifi_ap_record_t],
+    ) -> Result<usize, EspError> {
         info!("About to get info for found access points");
 
         // let mut ap_info_raw = [0 as u8; std::mem::size_of::<wifi_ap_record_t>() * MAX_AP];
@@ -615,14 +686,21 @@ impl EspWifi {
 
         let mut ap_count: u16 = ap_infos_raw.len() as u16;
 
-        esp!(unsafe {esp_wifi_scan_get_ap_records(&mut ap_count, ap_infos_raw.as_mut_ptr() /*as *mut wifi_ap_record_t*/)})?;
+        esp!(unsafe {
+            esp_wifi_scan_get_ap_records(
+                &mut ap_count,
+                ap_infos_raw.as_mut_ptr(), /*as *mut wifi_ap_record_t*/
+            )
+        })?;
 
         Ok(ap_count as usize)
     }
 
     unsafe fn clear_ip_conf(netif: &mut *mut esp_netif_t) -> Result<(), EspError> {
         if !(*netif).is_null() {
-            esp!(esp_wifi_clear_default_wifi_driver_and_handlers(*netif as *mut c_types::c_void))?;
+            esp!(esp_wifi_clear_default_wifi_driver_and_handlers(
+                *netif as *mut c_types::c_void
+            ))?;
             esp_netif_destroy(*netif);
 
             *netif = ptr::null_mut();
@@ -633,14 +711,19 @@ impl EspWifi {
         Ok(())
     }
 
-    unsafe extern "C" fn event_handler(arg: *mut c_types::c_void, event_base: esp_event_base_t, event_id: c_types::c_int, event_data: *mut c_types::c_void) {
+    unsafe extern "C" fn event_handler(
+        arg: *mut c_types::c_void,
+        event_base: esp_event_base_t,
+        event_id: c_types::c_int,
+        event_data: *mut c_types::c_void,
+    ) {
         #[cfg(feature = "std")]
         let shared_ref = (arg as *mut EspStdRwLock<Shared>).as_mut().unwrap();
 
         #[cfg(not(feature = "std"))]
         let shared_ref = (arg as *mut mutex::EspMutex<Shared>).as_mut().unwrap();
 
-        shared_ref.lock(|shared|
+        shared_ref.lock(|shared| {
             if event_base == WIFI_EVENT {
                 Self::on_wifi_event(shared, event_id, event_data)
             } else if event_base == IP_EVENT {
@@ -649,31 +732,45 @@ impl EspWifi {
                 warn!("Got unknown event base");
 
                 Ok(())
-            }.unwrap()
-        );
+            }
+            .unwrap()
+        });
     }
 
     #[allow(non_upper_case_globals)]
-    unsafe fn on_wifi_event(shared: &mut Shared, event_id: c_types::c_int, _event_data: *mut c_types::c_void) -> Result<(), EspError> {
+    unsafe fn on_wifi_event(
+        shared: &mut Shared,
+        event_id: c_types::c_int,
+        _event_data: *mut c_types::c_void,
+    ) -> Result<(), EspError> {
         info!("Got wifi event: {} ", event_id);
 
         shared.status = Status(
             match event_id as u32 {
-                wifi_event_t_WIFI_EVENT_STA_START => EspWifi::reconnect_if_operating(shared.operating)?,
+                wifi_event_t_WIFI_EVENT_STA_START => {
+                    EspWifi::reconnect_if_operating(shared.operating)?
+                }
                 wifi_event_t_WIFI_EVENT_STA_STOP => ClientStatus::Stopped,
-                wifi_event_t_WIFI_EVENT_STA_CONNECTED => ClientStatus::Started(ClientConnectionStatus::Connected(match shared.client_ip_conf.as_ref() {
-                    None => ClientIpStatus::Disabled,
-                    Some(ipv4::ClientConfiguration::DHCP) => ClientIpStatus::Waiting,
-                    Some(ipv4::ClientConfiguration::Fixed(ref status)) => ClientIpStatus::Done(status.clone()),
-                })),
-                wifi_event_t_WIFI_EVENT_STA_DISCONNECTED => EspWifi::reconnect_if_operating(shared.operating)?,
+                wifi_event_t_WIFI_EVENT_STA_CONNECTED => ClientStatus::Started(
+                    ClientConnectionStatus::Connected(match shared.client_ip_conf.as_ref() {
+                        None => ClientIpStatus::Disabled,
+                        Some(ipv4::ClientConfiguration::DHCP) => ClientIpStatus::Waiting,
+                        Some(ipv4::ClientConfiguration::Fixed(ref status)) => {
+                            ClientIpStatus::Done(status.clone())
+                        }
+                    }),
+                ),
+                wifi_event_t_WIFI_EVENT_STA_DISCONNECTED => {
+                    EspWifi::reconnect_if_operating(shared.operating)?
+                }
                 _ => shared.status.0.clone(),
             },
             match event_id as u32 {
                 wifi_event_t_WIFI_EVENT_AP_START => ApStatus::Started(ApIpStatus::Waiting), // TODO
                 wifi_event_t_WIFI_EVENT_AP_STOP => ApStatus::Stopped,
                 _ => shared.status.1.clone(),
-            });
+            },
+        );
 
         info!("Set status: {:?}", shared.status);
 
@@ -683,7 +780,11 @@ impl EspWifi {
     }
 
     #[allow(non_upper_case_globals)]
-    unsafe fn on_ip_event(shared: &mut Shared, event_id: c_types::c_int, event_data: *mut c_types::c_void) -> Result<(), EspError> {
+    unsafe fn on_ip_event(
+        shared: &mut Shared,
+        event_id: c_types::c_int,
+        event_data: *mut c_types::c_void,
+    ) -> Result<(), EspError> {
         info!("Got IP event: {}", event_id);
 
         shared.status = Status(
@@ -691,20 +792,25 @@ impl EspWifi {
                 ip_event_t_IP_EVENT_STA_GOT_IP => {
                     let event: *const ip_event_got_ip_t = mem::transmute(event_data);
 
-                    ClientStatus::Started(ClientConnectionStatus::Connected(ClientIpStatus::Done(ipv4::ClientSettings {
-                        ip: ipv4::Ipv4Addr::from(Newtype((*event).ip_info.ip)),
-                        subnet: ipv4::Subnet {
-                            gateway: ipv4::Ipv4Addr::from(Newtype((*event).ip_info.gw)),
-                            mask: Newtype((*event).ip_info.netmask).try_into()?,
+                    ClientStatus::Started(ClientConnectionStatus::Connected(ClientIpStatus::Done(
+                        ipv4::ClientSettings {
+                            ip: ipv4::Ipv4Addr::from(Newtype((*event).ip_info.ip)),
+                            subnet: ipv4::Subnet {
+                                gateway: ipv4::Ipv4Addr::from(Newtype((*event).ip_info.gw)),
+                                mask: Newtype((*event).ip_info.netmask).try_into()?,
+                            },
+                            dns: None,           // TODO
+                            secondary_dns: None, // TODO
                         },
-                        dns: None, // TODO
-                        secondary_dns: None, // TODO
-                    })))
+                    )))
                 }
-                ip_event_t_IP_EVENT_STA_LOST_IP => EspWifi::reconnect_if_operating(shared.operating)?,
+                ip_event_t_IP_EVENT_STA_LOST_IP => {
+                    EspWifi::reconnect_if_operating(shared.operating)?
+                }
                 _ => shared.status.0.clone(),
             },
-            shared.status.1.clone());
+            shared.status.1.clone(),
+        );
 
         info!("Set status: {:?}", shared.status);
 
@@ -743,7 +849,7 @@ impl Wifi for EspWifi {
     type Error = EspError;
 
     fn get_capabilities(&self) -> Result<EnumSet<Capability>, Self::Error> {
-        let caps = Capability::Client | Capability::AccessPoint| Capability::Mixed;
+        let caps = Capability::Client | Capability::AccessPoint | Capability::Mixed;
 
         info!("Providing capabilities: {:?}", caps);
 
@@ -770,7 +876,8 @@ impl Wifi for EspWifi {
 
         if ap_infos.len() > 0 {
             let mut ap_infos_raw_u8 = [0 as u8; mem::size_of::<wifi_ap_record_t>() * MAX_AP];
-            let ap_infos_raw: &mut [wifi_ap_record_t; MAX_AP] = unsafe {mem::transmute(&mut ap_infos_raw_u8)};
+            let ap_infos_raw: &mut [wifi_ap_record_t; MAX_AP] =
+                unsafe { mem::transmute(&mut ap_infos_raw_u8) };
 
             let real_count = self.do_get_scan_infos(ap_infos_raw)?;
 
@@ -798,8 +905,9 @@ impl Wifi for EspWifi {
 
         let total_count = self.do_scan()?;
 
-        let mut ap_infos_raw: vec::Vec<wifi_ap_record_t> = vec::Vec::with_capacity(total_count as usize);
-        unsafe {ap_infos_raw.set_len(total_count as usize)};
+        let mut ap_infos_raw: vec::Vec<wifi_ap_record_t> =
+            vec::Vec::with_capacity(total_count as usize);
+        unsafe { ap_infos_raw.set_len(total_count as usize) };
 
         let real_count = self.do_get_scan_infos(&mut ap_infos_raw)?;
 
@@ -826,8 +934,10 @@ impl Wifi for EspWifi {
                 wifi_mode_t_WIFI_MODE_NULL => Configuration::None,
                 wifi_mode_t_WIFI_MODE_AP => Configuration::AccessPoint(self.get_ap_conf()?),
                 wifi_mode_t_WIFI_MODE_STA => Configuration::Client(self.get_client_conf()?),
-                wifi_mode_t_WIFI_MODE_APSTA => Configuration::Mixed(self.get_client_conf()?, self.get_ap_conf()?),
-                _ => panic!()
+                wifi_mode_t_WIFI_MODE_APSTA => {
+                    Configuration::Mixed(self.get_client_conf()?, self.get_ap_conf()?)
+                }
+                _ => panic!(),
             };
 
             info!("Configuration gotten: {:?}", &conf);
@@ -848,21 +958,21 @@ impl Wifi for EspWifi {
                     info!("Wifi mode NULL set");
 
                     Status(ClientStatus::Stopped, ApStatus::Stopped)
-                },
+                }
                 Configuration::AccessPoint(ap_conf) => {
                     esp!(esp_wifi_set_mode(wifi_mode_t_WIFI_MODE_AP))?;
                     info!("Wifi mode AP set");
 
                     self.set_ap_conf(ap_conf)?;
                     Status(ClientStatus::Stopped, ApStatus::Starting)
-                },
+                }
                 Configuration::Client(client_conf) => {
                     esp!(esp_wifi_set_mode(wifi_mode_t_WIFI_MODE_STA))?;
                     info!("Wifi mode STA set");
 
                     self.set_client_conf(client_conf)?;
                     Status(ClientStatus::Starting, ApStatus::Stopped)
-                },
+                }
                 Configuration::Mixed(client_conf, ap_conf) => {
                     esp!(esp_wifi_set_mode(wifi_mode_t_WIFI_MODE_APSTA))?;
                     info!("Wifi mode APSTA set");
@@ -870,7 +980,7 @@ impl Wifi for EspWifi {
                     self.set_client_conf(client_conf)?;
                     self.set_ap_conf(ap_conf)?;
                     Status(ClientStatus::Starting, ApStatus::Starting)
-                },
+                }
             }
         };
 


### PR DESCRIPTION
- Disambiguate calls to `log` crate with `::log` due to compile issue
- Format with `cargo +nightly fmt`