### PR TITLE
httpd: use `set_type` for `Content-Type` header

### DIFF
--- a/src/httpd.rs
+++ b/src/httpd.rs
@@ -44,9 +44,16 @@ impl<'r> IdfRequest<'r> {
         }
 
         for (c_field, c_value) in &c_headers {
-            esp!(unsafe {
-                esp_idf_sys::httpd_resp_set_hdr(self.0, c_field.as_ptr(), c_value.as_ptr())
-            })?;
+            match c_field.as_bytes() {
+                b"content-type" | b"Content-Type" => {
+                    esp!(unsafe { esp_idf_sys::httpd_resp_set_type(self.0, c_value.as_ptr()) })?
+                }
+                _ => {
+                    esp!(unsafe {
+                        esp_idf_sys::httpd_resp_set_hdr(self.0, c_field.as_ptr(), c_value.as_ptr())
+                    })?;
+                }
+            }
         }
 
         match response.body {


### PR DESCRIPTION
`esp-idf` httpd always sends content type by the value set in the session context, see [here](https://github.com/espressif/esp-idf/blob/e5f5eb3cbb5d6cf65e25dd8d64f1cced36f2ca49/components/esp_http_server/src/httpd_txrx.c#L238). This PR captures `Content-Type` headers from the Rust side, and calls the appropriate function to set the type in httpd.

Closes #9 