### PR TITLE
Embassy time requires embassy-sync mutex support even with just the time driver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ std = ["alloc", "anyhow/std", "log/std", "esp-idf-sys/std", "esp-idf-hal/std", "
 alloc = ["anyhow", "esp-idf-hal/alloc", "embedded-svc/alloc"]
 nightly = ["embedded-svc/nightly"]
 experimental = ["embedded-svc/experimental"]
-embassy-time-driver = ["embassy-time"]
+embassy-time-driver = ["embassy-time", "esp-idf-hal/embassy-sync"]
 embassy-time-isr-queue = ["embassy-sync", "embassy-time", "esp-idf-hal/embassy-sync"]
 
 [dependencies]


### PR DESCRIPTION
Embassy-time requires embassy-sync mutex support internally when used with the generic queue.
Without this, it will have trouble finding the mutexes.
There is a related issue where esp-idf-hal does not enable critical-section (ever, actually)
when embassy-sync is in used, causing a linking error.
A PR for esp-idf-hal is coming in a moment.
