### PR TITLE
Added set/get_max_tx_power for Wifi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bluetooth: New methods `EspBleGap::start_scanning` and `EspBleGap::stop_scanning`
 - New example, `bt_ble_gap_scanner` to demonstrate usage of added ble scanning methods
 - New example, `mdns_advertise` to demonstrate mDNS service advertisement
+- Wifi: New methods `set_max_tx_power`, `get_max_tx_power`
 
 ## [0.51.0] - 2025-01-15
 

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1170,6 +1170,24 @@ impl<'d> WifiDriver<'d> {
         esp!(unsafe { esp_wifi_set_mac(interface.into(), mac.as_ptr() as *mut _) })
     }
 
+    /// Sets the maximum transmission power of WiFi. \
+    /// The `power` unit is 0.25dBm. \
+    /// As per [`crate::sys::esp_wifi_set_max_tx_power`](crate::sys::esp_wifi_set_max_tx_power)
+    pub fn set_max_tx_power(&mut self, power: i8) -> Result<(), EspError> {
+        ::log::debug!("Set tx power to {power}*0.25dBm");
+        esp!(unsafe { esp_wifi_set_max_tx_power(power) })?;
+        Ok(())
+    }
+
+    /// Gets the maximum transmission power of WiFi. \
+    /// The returned `power` unit is 0.25dBm. \
+    /// As per [`crate::sys::esp_wifi_get_max_tx_power`](crate::sys::esp_wifi_get_max_tx_power)
+    pub fn get_max_tx_power(&self) -> Result<i8, EspError> {
+        let mut value = 0_i8;
+        esp!(unsafe { esp_wifi_get_max_tx_power(&mut value) })?;
+        Ok(value)
+    }
+
     /// Enable and start WPS
     pub fn start_wps(&mut self, config: &WpsConfig) -> Result<(), EspError> {
         let config = Newtype::<esp_wps_config_t>::try_from(config)?;
@@ -1803,6 +1821,16 @@ impl<'d> EspWifi<'d> {
     /// As per [`WifiDriver::set_mac()`].
     pub fn set_mac(&mut self, interface: WifiDeviceId, mac: [u8; 6]) -> Result<(), EspError> {
         self.driver_mut().set_mac(interface, mac)
+    }
+
+    /// As per [`WifiDriver::set_max_tx_power()`]
+    pub fn set_max_tx_power(&mut self, power: i8) -> Result<(), EspError> {
+        self.driver_mut().set_max_tx_power(power)
+    }
+
+    /// As per [`WifiDriver::get_max_tx_power()`]
+    pub fn get_max_tx_power(&self) -> Result<i8, EspError> {
+        self.driver().get_max_tx_power()
     }
 
     fn attach_netif(&mut self) -> Result<(), EspError> {


### PR DESCRIPTION
### Submission Checklist 📝
- [N/A] I have updated existing examples or added new ones (if applicable). 
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖
- Added set/get max_tx_power for Wifi
- The unit is 0.25dBm, same as esp idf

#### Description
I needed a way to increase wifi tx power. So I added a wrapper to esp idf `esp_wifi_set_max_tx_power ` and `esp_wifi_get_max_tx_power ` methods.

#### Testing
Set the power to maximum value of 2dBm (set value 8) -> ESP32C6 was able to connect to wifi from a shorter range
Set the power to maximum value of 20dBm (set value 80) -> ESP32C6 was able to connect to wifi from a greater range 