### PR TITLE
Extended logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix #570 (c_char vs i8 mismatch on newer rustc toolchains)
 
 ### Added
+- Logging configuration enhanced with a simpler setup where Rust logs can be configured to have a verbosity which is
+  disconnected from the verbosity of the ESP-IDF native C logging (#593)
 - OTA: New method - `EspFirmwareInfoLoad::fetch_native` - returning the full native ESP-IDF image descriptor structures
 - Added `use_serde` feature, which enables the `use_serde` feature of `embedded-svc` crate, allowing to deserialize configuration structs.
 - OTA: Allow specifying image size to speed up erase

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -1,0 +1,51 @@
+//! A simple example demonstrating logging with `EspIdfLogger`
+//! Uncomment one of the options and comment all the others to see how it operates
+
+use log::info;
+
+fn main() {
+    esp_idf_svc::sys::link_patches();
+
+    //
+    // Option 1
+    //
+    // Easiest option: initialize the `log` crate with a hard-coded log level and with `EspIdfLogger`
+
+    // esp_idf_svc::log::init(::log::LevelFilter::Info);
+
+    //
+    // Option 2
+    //
+    // This is the same as the above, but uses a `RUST_LOG` environment variable to set the log level
+    // If this environment variable is not set, it defaults to `Info`
+
+    esp_idf_svc::log::init_from_env();
+
+    //
+    // Option 3
+    //
+    // A third option is to initialize the logger in a way where its log level is controlled
+    // by the ESP-IDF log configuration
+    //
+    // This way both C and Rust logs are controlled by the same configuration in `sdkconfig.defaults`,
+    // but this is not always desired, hence the above options
+
+    // esp_idf_svc::log::init_from_esp_idf();
+
+    // This is equivalent to `init_from_esp_idf()` and only kept for backwards compatibility
+    // esp_idf_svc::log::EspLogger::initialize_default();
+
+    //
+    // Option 4
+    //
+    // You can also do it all in a custom way
+
+    // static LOGGER: esp_idf_svc::log::EspIdfLogger<()> = esp_idf_svc::log::EspIdfLogger::new(()); // You can pass your own log filter too
+    // use esp_idf_svc::log::LogFilterBackend;
+    // ::log::set_logger(&LOGGER)
+    //     .map(|()| LOGGER.filter().initialize())
+    //     .unwrap();
+    // ::log::set_max_level(::log::LevelFilter::Debug);
+
+    info!("Hello, world! This is a logging example using `EspIdfLogger`.");
+}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description

I've found out that our integrated logging - specifically - the fact that the Rust log level is hard-wired to the ESP-IDF log verbosity configuration - while powerful can be a bit intimidating to new users, in terms of understanding and configuring properly.

Furthermore, sometimes one might want to increase the logging verbosity of the Rust portion, _without_ increasing the log verbosity of the ESP IDF itself, because the latter often comes with a much-increased stack requirements.

Therefore, what this PR introduces are 3 separate ways to configure the ESP logger:
- `esp_idf_svc::log::init_from_esp_idf()` - this is the "integrated" logging where the logging verbosity of the Rust logs is wholly controlled by the ESP-IDF log settings (the `esp_idf_svc::log::EspLogger::initialize_default()` call is preserved and is equivalent)
- `esp_idf_svc::log::init(<level-filter>)` - a simple initialization of the Rust logging with a fixed logging level, irrespective of what the ESP-IDF native C log level verbosity is
- `esp_idf_svc::log::init_from_env()` - equivalent to the above, but the log level is taken from a `RUST_LOG` environment variable

Obviously, the user can also instantiate an `EspIdfLogger<T>` instance by herself and then initialize the `log` crate with it manually. This was anyway always possible, but so far the existing `EspLogger` was always hard-wired to the ESP-IDF log configuration.

#### Testing

With running an example with all possible options.