### PR TITLE
No longer hide BT, Thread, partitions and filesystems behind the experimental feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Simplifications:
   - `Thread::init` and `Thread::deinit` are now gone
   - No option to swap the Thread Netif with a custom one, as it complicates the implementation, and I don't see the use-case (unlike with Wifi)
+- MSRV raised to 1.82
 
 ### Fixed
 - Fix wrong conversion from `ScanType` to `u32` in Wi-Fi configuration
 - Fix wrong BT configuration version on the c6 (issue #556)
 - Fix inconsistent mutability in NVS (#567)
 - Fix #570 (c_char vs i8 mismatch on newer rustc toolchains)
+- ESP-IDF partitions support is no longer behind the `experimental` feature
+- Filesystems support is no longer behind the `experimental` feature
+- Bluetooth support is no longer behind the `experimental` feature
+- Thread support is no longer behind the `experimental` feature
 
 ### Added
 - Logging configuration enhanced with a simpler setup where Rust logs can be configured to have a verbosity which is

--- a/examples/bt_ble_gap_scanner.rs
+++ b/examples/bt_ble_gap_scanner.rs
@@ -1,5 +1,4 @@
 //! Example of a BLE GAP scanner using the ESP IDF Bluedroid BLE bindings.
-//! Build with `--features experimental` (for now).
 //!
 //! The example prints discovered ble devices on the console.
 //!
@@ -22,21 +21,17 @@
 #![allow(unknown_lints)]
 #![allow(unexpected_cfgs)]
 
-#[cfg(all(not(esp32s2), feature = "experimental"))]
+#[cfg(not(esp32s2))]
 fn main() -> anyhow::Result<()> {
     example::main()
 }
 
-#[cfg(any(esp32s2, not(feature = "experimental")))]
+#[cfg(esp32s2)]
 fn main() -> anyhow::Result<()> {
-    #[cfg(esp32s2)]
     panic!("ESP32-S2 does not have a BLE radio");
-
-    #[cfg(not(feature = "experimental"))]
-    panic!("Use `--features experimental` when building this example");
 }
 
-#[cfg(all(not(esp32s2), feature = "experimental"))]
+#[cfg(not(esp32s2))]
 mod example {
     use core::fmt;
     use core::hash::{Hash, Hasher};

--- a/examples/bt_gatt_server.rs
+++ b/examples/bt_gatt_server.rs
@@ -1,5 +1,4 @@
 //! Example of a BLE GATT server using the ESP IDF Bluedroid BLE bindings.
-//! Build with `--features experimental` (for now).
 //!
 //! You can test it with any "GATT Browser" app, like e.g.
 //! the "GATTBrowser" mobile app available on Android.
@@ -31,21 +30,17 @@
 #![allow(unknown_lints)]
 #![allow(unexpected_cfgs)]
 
-#[cfg(all(not(esp32s2), feature = "experimental"))]
+#[cfg(not(esp32s2))]
 fn main() -> anyhow::Result<()> {
     example::main()
 }
 
-#[cfg(any(esp32s2, not(feature = "experimental")))]
+#[cfg(esp32s2)]
 fn main() -> anyhow::Result<()> {
-    #[cfg(esp32s2)]
     panic!("ESP32-S2 does not have a BLE radio");
-
-    #[cfg(not(feature = "experimental"))]
-    panic!("Use `--features experimental` when building this example");
 }
 
-#[cfg(all(not(esp32s2), feature = "experimental"))]
+#[cfg(not(esp32s2))]
 mod example {
     use std::sync::{Arc, Condvar, Mutex};
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -15,7 +15,7 @@ pub mod vfs {
     #[cfg(esp_idf_soc_usb_serial_jtag_supported)]
     use crate::sys::{esp_vfs_usb_serial_jtag_use_driver, esp_vfs_usb_serial_jtag_use_nonblocking};
 
-    #[cfg(all(feature = "experimental", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     extern crate alloc;
 
     /// Represents a mounted EventFD pseudo-filesystem.
@@ -48,13 +48,13 @@ pub mod vfs {
     }
 
     /// Represents a mounted SPIFFS filesystem.
-    #[cfg(all(feature = "experimental", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     pub struct MountedSpiffs<T> {
         _spiffs: T,
         path: alloc::ffi::CString,
     }
 
-    #[cfg(all(feature = "experimental", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     impl<T> MountedSpiffs<T> {
         /// Mount a SPIFFS filesystem.
         ///
@@ -84,7 +84,7 @@ pub mod vfs {
         }
     }
 
-    #[cfg(all(feature = "experimental", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     impl<T> Drop for MountedSpiffs<T> {
         fn drop(&mut self) {
             sys::esp!(unsafe { sys::esp_vfs_spiffs_unregister(self.path.as_ptr()) }).unwrap();
@@ -92,7 +92,7 @@ pub mod vfs {
     }
 
     /// Represents a mounted FAT filesystem.
-    #[cfg(all(feature = "experimental", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     pub struct MountedFatfs<T> {
         _handle: *mut sys::FATFS,
         _fatfs: T,
@@ -100,7 +100,7 @@ pub mod vfs {
         drive: u8,
     }
 
-    #[cfg(all(feature = "experimental", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     impl<T> MountedFatfs<T> {
         /// Mount a FAT filesystem.
         ///
@@ -141,7 +141,7 @@ pub mod vfs {
         }
     }
 
-    #[cfg(all(feature = "experimental", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     impl<T> Drop for MountedFatfs<T> {
         fn drop(&mut self) {
             let drive_path = crate::fs::fatfs::Fatfs::<()>::drive_path_from(self.drive);
@@ -155,21 +155,13 @@ pub mod vfs {
     }
 
     /// Represents a mounted Littlefs filesystem.
-    #[cfg(all(
-        feature = "experimental",
-        feature = "alloc",
-        esp_idf_comp_joltwallet__littlefs_enabled
-    ))]
+    #[cfg(all(feature = "alloc", esp_idf_comp_joltwallet__littlefs_enabled))]
     pub struct MountedLittlefs<T> {
         _littlefs: T,
         partition_raw_data: crate::fs::littlefs::PartitionRawData,
     }
 
-    #[cfg(all(
-        feature = "experimental",
-        feature = "alloc",
-        esp_idf_comp_joltwallet__littlefs_enabled
-    ))]
+    #[cfg(all(feature = "alloc", esp_idf_comp_joltwallet__littlefs_enabled))]
     impl<T> MountedLittlefs<T> {
         /// Mount a Littlefs filesystem.
         ///
@@ -256,11 +248,7 @@ pub mod vfs {
         }
     }
 
-    #[cfg(all(
-        feature = "experimental",
-        feature = "alloc",
-        esp_idf_comp_joltwallet__littlefs_enabled
-    ))]
+    #[cfg(all(feature = "alloc", esp_idf_comp_joltwallet__littlefs_enabled))]
     impl<T> Drop for MountedLittlefs<T> {
         fn drop(&mut self) {
             use crate::fs::littlefs::PartitionRawData;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,12 +27,7 @@ extern crate std;
 extern crate alloc;
 
 #[cfg(not(esp32s2))]
-#[cfg(all(
-    esp_idf_bt_enabled,
-    esp_idf_bt_bluedroid_enabled,
-    feature = "alloc",
-    feature = "experimental"
-))]
+#[cfg(all(esp_idf_bt_enabled, esp_idf_bt_bluedroid_enabled, feature = "alloc",))]
 pub mod bt;
 #[cfg(all(
     not(esp32h2),
@@ -58,7 +53,6 @@ pub mod espnow;
 pub mod eth;
 #[cfg(all(feature = "alloc", esp_idf_comp_esp_event_enabled))]
 pub mod eventloop;
-#[cfg(feature = "experimental")]
 pub mod fs;
 pub mod hal;
 pub mod handle;
@@ -90,10 +84,7 @@ pub mod nvs;
     any(esp_idf_comp_spi_flash_enabled, esp_idf_comp_esp_partition_enabled)
 ))]
 pub mod ota;
-#[cfg(all(
-    feature = "experimental",
-    any(esp_idf_comp_spi_flash_enabled, esp_idf_comp_esp_partition_enabled)
-))]
+#[cfg(any(esp_idf_comp_spi_flash_enabled, esp_idf_comp_esp_partition_enabled))]
 pub mod partition;
 #[cfg(esp_idf_comp_esp_netif_enabled)]
 pub mod ping;
@@ -103,7 +94,6 @@ pub mod sys;
 pub mod systime;
 #[cfg(all(
     feature = "alloc",
-    feature = "experimental",
     esp_idf_comp_openthread_enabled,
     esp_idf_openthread_enabled,
     esp_idf_comp_esp_event_enabled,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description

Subject says it all. I use BT & Thread with Matter, and the FS & partitions modules in production. Moreover, a lot of this code had stayed behind "experimental" for a long time (BT particularly) so for better discoverability I think we should finally promote it.

#### Testing
n/a
