### PR TITLE
Support for last-will messages with empty payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Filesystems support is no longer behind the `experimental` feature
 - Bluetooth support is no longer behind the `experimental` feature
 - Thread support is no longer behind the `experimental` feature
+- MQTT: Fix a crash when the LWT payload is empty (#597)
 
 ### Added
 - Compatibility with ESP-IDF V5.4.x and V5.5.x

--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -184,7 +184,13 @@ impl<'a> TryFrom<&'a MqttClientConfiguration<'a>>
 
         if let Some(lwt) = conf.lwt.as_ref() {
             c_conf.lwt_topic = cstrs.as_ptr(lwt.topic)?;
-            c_conf.lwt_msg = lwt.payload.as_ptr() as _;
+            c_conf.lwt_msg = if lwt.payload.is_empty() {
+                // ... or else len = 0 will cause ESP-IDF to treat our pointer as
+                // if it points to a C string, which it definitely doesn't
+                core::ptr::null()
+            } else {
+                lwt.payload.as_ptr() as _
+            };
             c_conf.lwt_msg_len = lwt.payload.len() as _;
             c_conf.lwt_qos = lwt.qos as _;
             c_conf.lwt_retain = lwt.retain as _;


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description

ESP-IDF's MQTT client has the weird oddity that if we pass a non-null pointer to the LWT payload - yet - we pass a length of 0 - then it treats the payload as if it is an ASCIIZ (C) string, and excercises `strdup` and friends on it, which leads to out of bound reads.

The fix is to pass a NULL pointer when our LWT payload is zero-length.

#### Testing
n/a