### PR TITLE
Handle the new dataset-changed event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Simplifications:
   - `Thread::init` and `Thread::deinit` are now gone
   - No option to swap the Thread Netif with a custom one, as it complicates the implementation, and I don't see the use-case (unlike with Wifi)
+ - Compatibility with ESP-IDF 5.1.6+, 5.2.4+, 5.3.2+ and 5.4+ in that the new DatasetChanged event is properly handled and does not cause the event code to panic
 - MSRV raised to 1.82
 - NVS: Removed `NvsDataType::Any` and replaced `From<nvs_type_t>` with `NvsDataType:from_nvs_type`
 - (#529) `Peripheral` and `PeripheralRef` removed and replaced with a simple pattern similar to the `esp-hal` one.

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -2003,6 +2003,13 @@ pub enum ThreadEvent {
         ),
     ))]
     MeshcopERemoveStarted,
+    #[cfg(any(
+        esp_idf_version_patch_at_least_5_1_6,
+        esp_idf_version_patch_at_least_5_2_4,
+        esp_idf_version_patch_at_least_5_3_2,
+        esp_idf_version_at_least_5_4_0
+    ))]
+    DatasetChanged,
 }
 
 unsafe impl EspEventSource for ThreadEvent {
@@ -2094,6 +2101,13 @@ impl EspEventDeserializer for ThreadEvent {
             esp_openthread_event_t_OPENTHREAD_EVENT_REMOVE_MESHCOP_E => {
                 ThreadEvent::MeshcopERemoveStarted
             }
+            #[cfg(any(
+                esp_idf_version_patch_at_least_5_1_6,
+                esp_idf_version_patch_at_least_5_2_4,
+                esp_idf_version_patch_at_least_5_3_2,
+                esp_idf_version_at_least_5_4_0
+            ))]
+            esp_openthread_event_t_OPENTHREAD_EVENT_DATASET_CHANGED => ThreadEvent::DatasetChanged,
             _ => panic!("unknown event ID: {event_id}"),
         }
     }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

There's a new DatasetChanged thread event which causes the event handling code to panic.

#### Description

The event is properly mapped and handled.

#### Testing

Not tested yet.