### PR TITLE
chore: Removed lifetimes; the compiler can deduce them

### DIFF
--- a/src/eth.rs
+++ b/src/eth.rs
@@ -51,16 +51,16 @@ pub enum RmiiEthChipset {
 }
 
 #[cfg(all(esp32, esp_idf_eth_use_esp32_emac))]
-pub enum RmiiClockConfig<'d> {
-    Input(gpio::Gpio0<'d>),
-    OutputGpio0(gpio::Gpio0<'d>),
+pub enum RmiiClockConfig {
+    Input(gpio::Gpio0),
+    OutputGpio0(gpio::Gpio0),
     /// This according to ESP-IDF is for "testing" only    
-    OutputGpio16(gpio::Gpio16<'d>),
-    OutputInvertedGpio17(gpio::Gpio17<'d>),
+    OutputGpio16(gpio::Gpio16),
+    OutputInvertedGpio17(gpio::Gpio17),
 }
 
 #[cfg(all(esp32, esp_idf_eth_use_esp32_emac))]
-impl RmiiClockConfig<'_> {
+impl RmiiClockConfig {
     fn eth_mac_clock_config(&self) -> eth_mac_clock_config_t {
         let rmii = match self {
             Self::Input(_) => eth_mac_clock_config_t__bindgen_ty_2 {
@@ -291,16 +291,16 @@ pub struct EthDriver<'d, T> {
 impl<'d> EthDriver<'d, RmiiEth> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        mac: crate::hal::mac::MAC<'d>,
-        rmii_rdx0: gpio::Gpio25<'d>,
-        rmii_rdx1: gpio::Gpio26<'d>,
-        rmii_crs_dv: gpio::Gpio27<'d>,
+        mac: crate::hal::mac::MAC,
+        rmii_rdx0: gpio::Gpio25,
+        rmii_rdx1: gpio::Gpio26,
+        rmii_crs_dv: gpio::Gpio27,
         rmii_mdc: impl gpio::OutputPin + 'd,
-        rmii_txd1: gpio::Gpio22<'d>,
-        rmii_tx_en: gpio::Gpio21<'d>,
-        rmii_txd0: gpio::Gpio19<'d>,
+        rmii_txd1: gpio::Gpio22,
+        rmii_tx_en: gpio::Gpio21,
+        rmii_txd0: gpio::Gpio19,
         rmii_mdio: impl gpio::InputPin + gpio::OutputPin + 'd,
-        rmii_ref_clk_config: RmiiClockConfig<'d>,
+        rmii_ref_clk_config: RmiiClockConfig,
         rst: Option<impl gpio::OutputPin + 'd>,
         chipset: RmiiEthChipset,
         phy_addr: Option<u32>,
@@ -326,16 +326,16 @@ impl<'d> EthDriver<'d, RmiiEth> {
 
     #[allow(clippy::too_many_arguments)]
     pub fn new_rmii(
-        _mac: crate::hal::mac::MAC<'d>,
-        _rmii_rdx0: gpio::Gpio25<'d>,
-        _rmii_rdx1: gpio::Gpio26<'d>,
-        _rmii_crs_dv: gpio::Gpio27<'d>,
+        _mac: crate::hal::mac::MAC,
+        _rmii_rdx0: gpio::Gpio25,
+        _rmii_rdx1: gpio::Gpio26,
+        _rmii_crs_dv: gpio::Gpio27,
         rmii_mdc: impl gpio::OutputPin + 'd,
-        _rmii_txd1: gpio::Gpio22<'d>,
-        _rmii_tx_en: gpio::Gpio21<'d>,
-        _rmii_txd0: gpio::Gpio19<'d>,
+        _rmii_txd1: gpio::Gpio22,
+        _rmii_tx_en: gpio::Gpio21,
+        _rmii_txd0: gpio::Gpio19,
         rmii_mdio: impl gpio::InputPin + gpio::OutputPin + 'd,
-        rmii_ref_clk_config: RmiiClockConfig<'d>,
+        rmii_ref_clk_config: RmiiClockConfig,
         rst: Option<impl gpio::OutputPin + 'd>,
         chipset: RmiiEthChipset,
         phy_addr: Option<u32>,
@@ -381,7 +381,7 @@ impl<'d> EthDriver<'d, RmiiEth> {
         Ok(phy)
     }
 
-    fn rmii_mac(mdc: i32, mdio: i32, clk_config: &RmiiClockConfig<'d>) -> *mut esp_eth_mac_t {
+    fn rmii_mac(mdc: i32, mdio: i32, clk_config: &RmiiClockConfig) -> *mut esp_eth_mac_t {
         #[cfg(esp_idf_version_major = "4")]
         let mac = {
             let mut config = Self::eth_mac_default_config(mdc, mdio);


### PR DESCRIPTION
Small fixes to make it build again. Removed some redundant and non-required lifetimes.