### PR TITLE
docs(eth): recommend interrupt over polling

### DIFF
--- a/src/eth.rs
+++ b/src/eth.rs
@@ -150,7 +150,7 @@ impl<'d> SpiEventSource<'d> {
     /// Instead of getting informed by an interrupt pin about updates/changes from the emac, the
     /// MCU polls the emac periodically for updates.
     ///
-    /// In most cases, [`Self::polling`] should be used as it is more efficient.
+    /// In most cases, [`Self::interrupt`] should be used as it is more efficient.
     /// But this source makes e.g. sense if the interrupt pin of the emac is not connected to the MCU.
     #[cfg(not(any(
         esp_idf_version_major = "4",


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
Changed [SpiEthEventSource](https://docs.esp-rs.org/esp-idf-svc/esp_idf_svc/eth/struct.SpiEventSource.html#method.polling) to recommend `interrupt` instead of `polling`. I believe the recommendation of `polling` is a mistake, since grammatically it refers to itself, and logically the stated reason (efficiency) lends itself to interrupts.

#### Testing
No tests, just a doc (comment) change.