### PR TITLE
Disable Wifi for esp32p4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - NVS: Implemented `RawHandle` for `EspNvs<NvsDefault>`
 - NVS: Added `EspNvs::erase_all` to remove all data stored in an nvs namespace
 - NVS: Added `EspNvs::keys` to iterate over all stored keys
+- esp32p4: This chip has no radio, so wifi has been disabled for this
 
 ## [0.51.0] - 2025-01-15
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ pub mod thread;
 pub mod timer;
 pub mod tls;
 #[cfg(all(
-    not(esp32h2),
+    not(any(esp32h2, esp32p4)),
     feature = "alloc",
     esp_idf_comp_esp_wifi_enabled,
     esp_idf_comp_esp_event_enabled,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
The esp32p4 doesn't have native wifi support as per https://docs.espressif.com/projects/esp-idf/en/stable/esp32p4/api-guides/wifi-expansion.html.

#### Testing
Combined with https://github.com/esp-rs/esp-idf-sys/pull/401 and https://github.com/esp-rs/esp-idf-hal/pull/564, I was able to get the hello world generated from https://github.com/esp-rs/esp-idf-template working on esp32p4. Please refer to https://github.com/esp-rs/esp-idf-hal/pull/564 for more detailed information on this.