### PR TITLE
Fix EspWebSocketClientConfig timeout fields not passed to C struct (#635)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bluetooth support is no longer behind the `experimental` feature
 - Thread support is no longer behind the `experimental` feature
 - MQTT: Fix a crash when the LWT payload is empty (#597)
+- WS: Fix `EspWebSocketClientConfig` `reconnect_timeout_ms` and `network_timeout_ms` fields not being passed to the underlying C struct (#635)
 
 ### Added
 - Compatibility with ESP-IDF V5.4.x and V5.5.x

--- a/src/ws/client.rs
+++ b/src/ws/client.rs
@@ -239,6 +239,8 @@ impl<'a> TryFrom<&'a EspWebSocketClientConfig<'a>> for (esp_websocket_client_con
             #[cfg(not(esp_idf_version_major = "4"))]
             crt_bundle_attach: conf.crt_bundle_attach,
 
+            reconnect_timeout_ms: conf.reconnect_timeout_ms.as_millis() as _,
+            network_timeout_ms: conf.network_timeout_ms.as_millis() as _,
             ping_interval_sec: conf.ping_interval_sec.as_secs() as _,
 
             cert_pem: conf


### PR DESCRIPTION
Fixes #635

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
 The `EspWebSocketClientConfig` struct exposes `reconnect_timeout_ms` and `network_timeout_ms` as public fields, but the `TryFrom` implementation that converts the config to `esp_websocket_client_config_t` never assigns them to the C struct. They fall through to `..Default::default()`, which zeroes them out, causing the C library to silently fall back to its 10-second defaults regardless of what the user sets.

This fix adds the two missing assignments in the struct initializer:

```
  reconnect_timeout_ms: conf.reconnect_timeout_ms.as_millis() as _,
  network_timeout_ms: conf.network_timeout_ms.as_millis() as _,
```

This is a no-op for existing code that uses `Default`, since `Duration::default()` is zero and the C library already treats zero as "use the default". It only changes behavior for users who explicitly set these fields which previously  had no effect.


#### Testing
I came across the bug by using the WS client in a project and I am already using the fixed version (vendored).