### PR TITLE
Add task_caps to http server `Configuration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - NVS: Removed `NvsDataType::Any` and replaced `From<nvs_type_t>` with `NvsDataType:from_nvs_type`
 - (#529) `Peripheral` and `PeripheralRef` removed and replaced with a simple pattern similar to the `esp-hal` one.
   - Check https://github.com/esp-rs/esp-idf-hal/pull/529 for details on that change
+- HTTP: added `task_caps` option into server `Configuration`
 
 ### Fixed
 - `WifiDriver::get_ap_info` not takes `&self` instead of `&mut self`. Convenience method `EspWifi::get_ap_info` that delegates

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -89,6 +89,7 @@ pub struct Configuration {
     pub core: Option<Core>,
     pub max_sessions: usize,
     pub session_timeout: Duration,
+    pub task_caps: u32,
     pub stack_size: usize,
     pub max_open_sockets: usize,
     pub max_uri_handlers: usize,
@@ -110,6 +111,7 @@ impl Default for Configuration {
             core: None,
             max_sessions: 16,
             session_timeout: Duration::from_secs(20 * 60),
+            task_caps: (MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT),
             #[cfg(not(esp_idf_esp_https_server_enable))]
             stack_size: 6144,
             #[cfg(esp_idf_esp_https_server_enable)]
@@ -144,7 +146,7 @@ impl From<&Configuration> for Newtype<httpd_config_t> {
                     ))
                 ),
             ))]
-            task_caps: (MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT),
+            task_caps: conf.task_caps,
             stack_size: conf.stack_size,
             core_id: conf.core.map(|core| core.into()).unwrap_or(i32::MAX),
             server_port: conf.http_port,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖
Exposes the task_caps configuration option on http server

#### Description
In http server `Configuration` exposes `task_caps`. Specifically my motivation is to be able to use `MALLOC_CAP_SPIRAM` to save lots of internal memory.

Could make an `Option` in order to prevent breaking change but this is more code correct.

#### Testing
Ran locally with changes, small change