### PR TITLE
Support esp_wifi_remote for esp32p4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - NVS: Implemented `RawHandle` for `EspNvs<NvsDefault>`
 - NVS: Added `EspNvs::erase_all` to remove all data stored in an nvs namespace
 - NVS: Added `EspNvs::keys` to iterate over all stored keys
-- esp32p4: This chip has no radio, so wifi has been disabled for this
+- esp32p4: This chip has no radio, but can use wifi via esp_wifi_remote. Support for esp_wifi_remote has been added.
 - HTTP: added `keep_alive_*` option into configuration
 
 ## [0.51.0] - 2025-01-15

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,9 +105,9 @@ pub mod thread;
 pub mod timer;
 pub mod tls;
 #[cfg(all(
-    not(any(esp32h2, esp32p4)),
+    not(esp32h2),
     feature = "alloc",
-    esp_idf_comp_esp_wifi_enabled,
+    any(esp_idf_comp_esp_wifi_enabled, esp_idf_comp_esp_wifi_remote_enabled),
     esp_idf_comp_esp_event_enabled,
 ))]
 pub mod wifi;


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
Wifi is now supported for esp32p4 via the use of esp_wifi_remote. This is largely a drop in replacement, but has some behavioral differences, so we have some branching paths that are more tolerant of failure in this situations.

#### Testing

Using a small test app and some changes from esp-idf-sys:

```
I (3589) RPC_WRAP: Coprocessor Boot-up
E (3740) system_api: 0 mac type is incorrect (not found)
E (3741) system_api: 1 mac type is incorrect (not found)
W (3766) rpc_utils: Event: SSID XXXXX
I (3785) osc_pedal: Starting WiFi...
I (3892) RPC_WRAP: ESP Event: wifi station started
I (3912) RPC_WRAP: ESP Event: wifi station started
I (4028) osc_pedal: WiFi started. Connecting...
I (4028) H_API: esp_wifi_remote_connect
I (6923) RPC_WRAP: ESP Event: Station mode: Connected
I (6923) esp_wifi_remote: esp_wifi_internal_reg_rxcb: sta: 0x40077b54
I (6940) osc_pedal: WiFi connected. Waiting for network interface...
I (8348) esp_netif_handlers: sta ip: 192.168.1.130, mask: 255.255.0.0, gw: 192.168.1.1
I (8376) osc_pedal: WiFi connected! IP: 192.168.1.130
I (8376) osc_pedal: WiFi test passed!
```

Related to:
- https://github.com/esp-rs/esp-idf-hal/pull/572
- https://github.com/esp-rs/esp-idf-sys/pull/404