### PR TITLE
Fix ESP-IDF v6.0 API compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           - v5.3.4
           - v5.4.3
           - v5.5.3
+          - v6.0
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v3
@@ -60,7 +61,7 @@ jobs:
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
-          RUSTFLAGS: "${{ !startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time64' || startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' }}"
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' || '--cfg espidf_time64' }}"
         run: cargo clippy --features nightly,experimental --no-deps --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -- -Dwarnings
 
       - name: Build | Compile
@@ -68,7 +69,7 @@ jobs:
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
-          RUSTFLAGS: "${{ !startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time64' || startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' }}"
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' || '--cfg espidf_time64' }}"
         run: cargo build --target ${{ matrix.target }} -Zbuild-std=std,panic_abort
 
       - name: Build | Compile, experimental, nightly, no_std
@@ -76,7 +77,7 @@ jobs:
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
-          RUSTFLAGS: "${{ !startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time64' || startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' }}"
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' || '--cfg espidf_time64' }}"
         run: cargo build --no-default-features --features nightly,experimental --target ${{ matrix.target }} -Zbuild-std=std,panic_abort
 
       - name: Build | Compile, experimental, nightly, alloc
@@ -84,7 +85,7 @@ jobs:
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
-          RUSTFLAGS: "${{ !startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time64' || startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' }}"
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' || '--cfg espidf_time64' }}"
         run: cargo build --no-default-features --features nightly,experimental,alloc --target ${{ matrix.target }} -Zbuild-std=std,panic_abort
 
       - name: Setup | ldproxy
@@ -99,7 +100,7 @@ jobs:
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
-          RUSTFLAGS: "${{ !startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time64' || startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' }}"
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' || '--cfg espidf_time64' }}"
           WIFI_SSID: "ssid"
           WIFI_PASS: "pass"
           ESP_DEVICE_IP: "192.168.1.250"
@@ -112,7 +113,7 @@ jobs:
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
-          RUSTFLAGS: "${{ !startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time64' || startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' }}"
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' || '--cfg espidf_time64' }}"
           WIFI_SSID: "ssid"
           WIFI_PASS: "pass"
           ESP_DEVICE_IP: "192.168.1.250"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `WifiEvent::DppUriReady` / `DppUriReadyRef` (v5.5.0+)
   - `WifiEvent::DppCfgRecvd` / `DppCfgRecvdRef` (v5.5.0+)
   - `WifiEvent::DppFailed` / `DppFailedRef` (v5.5.0+)
+- Note that in ESP-IDF V6.0, some drivers have been moved to external components (`mqtt`, ethernet PHY/SPI drivers). If the code fails to build, you may need to enable extra components in your `Cargo.toml`, e.g.:
+```toml
+[[package.metadata.esp-idf-sys.extra_components]]
+remote_component = { name = "espressif/lan87xx", version = "1.*" }
+```
 
 ### Fixed
 - WiFi: receiving any of the six new events listed above on ESP-IDF v5.3+ / v5.5+ no longer causes a panic (fixes #618)
+
+### Added
+- Compatibility with ESP-IDF V6.0.
+- Added support for the Generic Ethernet PHY driver: particularly useful on ESP-IDF 6.0+ as it is built-in.
 
 ## [0.52.1] - 2026-03-10
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,10 @@ embassy-futures = "0.1.2"
 embedded-storage = { version = "0.3", optional = true }
 futures-io = { version = "0.3", optional = true }
 
+[patch.crates-io]
+esp-idf-sys = { git = "https://github.com/mh0pe/esp-idf-sys", branch = "esp-idf-v6-support" }
+esp-idf-hal = { git = "https://github.com/mh0pe/esp-idf-hal", branch = "esp-idf-v6-support" }
+
 [build-dependencies]
 embuild = "0.33"
 

--- a/examples/eth.rs
+++ b/examples/eth.rs
@@ -1,6 +1,16 @@
 //! This example demonstrates how to configure an RMII based Ethernet adapter
 //!
 //! To use it, you need an RMII-capable Espressif MCU, like the original ESP32 chip
+//!
+//! Note: On ESP-IDF v6.0+, specific RMII PHY drivers were moved out of the main tree.
+//! This example uses `RmiiEthChipset::Generic` which is always available. To use a
+//! specific PHY, add the corresponding component to your `Cargo.toml`, e.g.:
+//! ```toml
+//! [[package.metadata.esp-idf-sys.extra_components]]
+//! remote_component = { name = "espressif/lan87xx", version = "1.*" }
+//! ```
+//! Other available PHY components: `espressif/ip101`, `espressif/dp83848`,
+//! `espressif/rtl8201`, `espressif/ksz80xx`.
 
 #![allow(unknown_lints)]
 #![allow(unexpected_cfgs)]
@@ -37,7 +47,12 @@ fn main() -> anyhow::Result<()> {
         pins.gpio18,
         esp_idf_svc::eth::RmiiClockConfig::OutputInvertedGpio17(pins.gpio17),
         Some(pins.gpio5),
-        // Replace with IP101 if you have that variant, or with some of the others in the `RmiiEthChipset`` enum
+        // Replace with a specific PHY variant (e.g. LAN87XX, IP101) if you have it available.
+        // On ESP-IDF v6.0+ these require external components (see note at top of file).
+        // Generic is available since ESP-IDF v5.4; use LAN87XX for older versions.
+        #[cfg(esp_idf_version_at_least_5_4_0)]
+        esp_idf_svc::eth::RmiiEthChipset::Generic,
+        #[cfg(not(esp_idf_version_at_least_5_4_0))]
         esp_idf_svc::eth::RmiiEthChipset::LAN87XX,
         Some(0),
         sys_loop.clone(),

--- a/examples/eth_spi_async.rs
+++ b/examples/eth_spi_async.rs
@@ -1,24 +1,68 @@
 //! This example demonstrates how to configure an SPI based Ethernet adapter
 //!
-//! To be able to use this example, you need to set the following in your sdkconfig.default file:
+//! To be able to use this example on ESP-IDF v5.x, you need to set the following in your
+//! sdkconfig.defaults file (pick one depending on your chip):
 //! CONFIG_ETH_SPI_ETHERNET_DM9051=y
 //! CONFIG_ETH_SPI_ETHERNET_W5500=y
 //! CONFIG_ETH_SPI_ETHERNET_KSZ8851SNL=y
-//! You only pick one of the three, depending on which chip you have on your board.
 //! Also adjust the EspEth::wrap call below to match your board's chip.
+//!
+//! Note: On ESP-IDF v6.0+, SPI Ethernet drivers were moved out of the main tree.
+//! Add the relevant component to your `Cargo.toml` depending on your chip:
+//! ```toml
+//! [[package.metadata.esp-idf-sys.extra_components]]
+//! remote_component = { name = "espressif/w5500", version = "1.*" }   # or dm9051, ksz8851snl
+//! ```
 
 #![allow(unknown_lints)]
 #![allow(unexpected_cfgs)]
 
+#[cfg(all(
+    esp32,
+    any(
+        esp_idf_eth_spi_ethernet_dm9051,
+        esp_idf_comp_espressif__dm9051_enabled,
+        esp_idf_eth_spi_ethernet_w5500,
+        esp_idf_comp_espressif__w5500_enabled,
+        esp_idf_eth_spi_ethernet_ksz8851snl,
+        esp_idf_comp_espressif__ksz8851snl_enabled
+    )
+))]
 fn main() {
-    #[cfg(esp32)]
     example::main().unwrap();
+}
 
-    #[cfg(not(esp32))]
+#[cfg(not(esp32))]
+fn main() {
     panic!("This example is configured for esp32, please adjust pins to your module");
 }
 
-#[cfg(esp32)]
+#[cfg(all(
+    esp32,
+    not(any(
+        esp_idf_eth_spi_ethernet_dm9051,
+        esp_idf_comp_espressif__dm9051_enabled,
+        esp_idf_eth_spi_ethernet_w5500,
+        esp_idf_comp_espressif__w5500_enabled,
+        esp_idf_eth_spi_ethernet_ksz8851snl,
+        esp_idf_comp_espressif__ksz8851snl_enabled
+    ))
+))]
+fn main() {
+    panic!("No SPI Ethernet chipset enabled. See the note at the top of this file.");
+}
+
+#[cfg(all(
+    esp32,
+    any(
+        esp_idf_eth_spi_ethernet_dm9051,
+        esp_idf_comp_espressif__dm9051_enabled,
+        esp_idf_eth_spi_ethernet_w5500,
+        esp_idf_comp_espressif__w5500_enabled,
+        esp_idf_eth_spi_ethernet_ksz8851snl,
+        esp_idf_comp_espressif__ksz8851snl_enabled
+    )
+))]
 pub mod example {
     use esp_idf_svc::eth;
     use esp_idf_svc::eventloop::EspSystemEventLoop;

--- a/examples/mqtt_client.rs
+++ b/examples/mqtt_client.rs
@@ -1,10 +1,20 @@
 //! MQTT blocking client example which subscribes to an internet MQTT server and then sends
 //! and receives events in its own topic.
+//!
+//! Note: On ESP-IDF v6.0+, the MQTT component was moved out of the main tree. To enable it,
+//! add the following to your `Cargo.toml`:
+//! ```toml
+//! [[package.metadata.esp-idf-sys.extra_components]]
+//! remote_component = { name = "espressif/mqtt", version = "1.*" }
+//! ```
 
 #![allow(unknown_lints)]
 #![allow(unexpected_cfgs)]
 
-#[cfg(not(any(esp32h2, esp32h4, esp32p4)))]
+#[cfg(all(
+    not(any(esp32h2, esp32h4, esp32p4)),
+    any(esp_idf_comp_mqtt_enabled, esp_idf_comp_espressif__mqtt_enabled)
+))]
 fn main() {
     example::main()
 }
@@ -14,7 +24,18 @@ fn main() {
     panic!("ESP32-H2, ESP32-H4 and ESP32-P4 do not have a Wifi radio (but you could enable the esp-wifi-remote component to use them with a WiFi co-processor)");
 }
 
-#[cfg(not(any(esp32h2, esp32h4, esp32p4)))]
+#[cfg(all(
+    not(any(esp32h2, esp32h4, esp32p4)),
+    not(any(esp_idf_comp_mqtt_enabled, esp_idf_comp_espressif__mqtt_enabled))
+))]
+fn main() {
+    panic!("MQTT component is not enabled. See the note at the top of this file.");
+}
+
+#[cfg(all(
+    not(any(esp32h2, esp32h4, esp32p4)),
+    any(esp_idf_comp_mqtt_enabled, esp_idf_comp_espressif__mqtt_enabled)
+))]
 mod example {
     use core::time::Duration;
 

--- a/examples/mqtt_client_async.rs
+++ b/examples/mqtt_client_async.rs
@@ -1,10 +1,20 @@
 //! MQTT asynchronous client example which subscribes to an internet MQTT server and then sends
 //! and receives events in its own topic.
+//!
+//! Note: On ESP-IDF v6.0+, the MQTT component was moved out of the main tree. To enable it,
+//! add the following to your `Cargo.toml`:
+//! ```toml
+//! [[package.metadata.esp-idf-sys.extra_components]]
+//! remote_component = { name = "espressif/mqtt", version = "1.*" }
+//! ```
 
 #![allow(unknown_lints)]
 #![allow(unexpected_cfgs)]
 
-#[cfg(not(any(esp32h2, esp32h4, esp32p4)))]
+#[cfg(all(
+    not(any(esp32h2, esp32h4, esp32p4)),
+    any(esp_idf_comp_mqtt_enabled, esp_idf_comp_espressif__mqtt_enabled)
+))]
 fn main() {
     example::main()
 }
@@ -14,7 +24,18 @@ fn main() {
     panic!("ESP32-H2, ESP32-H4 and ESP32-P4 do not have a Wifi radio (but you could enable the esp-wifi-remote component to use them with a WiFi co-processor)");
 }
 
-#[cfg(not(any(esp32h2, esp32h4, esp32p4)))]
+#[cfg(all(
+    not(any(esp32h2, esp32h4, esp32p4)),
+    not(any(esp_idf_comp_mqtt_enabled, esp_idf_comp_espressif__mqtt_enabled))
+))]
+fn main() {
+    panic!("MQTT component is not enabled. See the note at the top of this file.");
+}
+
+#[cfg(all(
+    not(any(esp32h2, esp32h4, esp32p4)),
+    any(esp_idf_comp_mqtt_enabled, esp_idf_comp_espressif__mqtt_enabled)
+))]
 mod example {
     use core::pin::pin;
     use core::time::Duration;

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -20,8 +20,11 @@ use embedded_svc::eth::*;
 use crate::hal::gpio;
 #[cfg(any(
     esp_idf_eth_spi_ethernet_dm9051,
+    esp_idf_comp_espressif__dm9051_enabled,
     esp_idf_eth_spi_ethernet_w5500,
-    esp_idf_eth_spi_ethernet_ksz8851snl
+    esp_idf_comp_espressif__w5500_enabled,
+    esp_idf_eth_spi_ethernet_ksz8851snl,
+    esp_idf_comp_espressif__ksz8851snl_enabled
 ))]
 use crate::hal::{spi, units::Hertz};
 
@@ -38,15 +41,42 @@ use crate::private::*;
 #[cfg(all(esp32, esp_idf_eth_use_esp32_emac))]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum RmiiEthChipset {
+    /// Use the generic IEEE 802.3-compliant PHY driver.
+    /// Available since ESP-IDF v5.4. On v6.0+, this is the only built-in option
+    /// unless specific PHY components from esp-eth-drivers are included.
+    #[cfg(esp_idf_version_at_least_5_4_0)]
+    Generic,
+    #[cfg(any(
+        not(esp_idf_version_at_least_6_0_0),
+        esp_idf_comp_espressif__ip101_enabled
+    ))]
     IP101,
+    #[cfg(any(
+        not(esp_idf_version_at_least_6_0_0),
+        esp_idf_comp_espressif__rtl8201_enabled
+    ))]
     RTL8201,
+    #[cfg(any(
+        not(esp_idf_version_at_least_6_0_0),
+        esp_idf_comp_espressif__lan87xx_enabled
+    ))]
     LAN87XX,
+    #[cfg(any(
+        not(esp_idf_version_at_least_6_0_0),
+        esp_idf_comp_espressif__dp83848_enabled
+    ))]
     DP83848,
     #[cfg(esp_idf_version_major = "4")]
     KSZ8041,
     #[cfg(esp_idf_version = "4.4")]
     KSZ8081,
-    #[cfg(not(esp_idf_version_major = "4"))]
+    #[cfg(all(
+        not(esp_idf_version_major = "4"),
+        any(
+            not(esp_idf_version_at_least_6_0_0),
+            esp_idf_comp_espressif__ksz80xx_enabled
+        )
+    ))]
     KSZ80XX,
 }
 
@@ -62,6 +92,7 @@ pub enum RmiiClockConfig<'d> {
 #[cfg(all(esp32, esp_idf_eth_use_esp32_emac))]
 impl RmiiClockConfig<'_> {
     fn eth_mac_clock_config(&self) -> eth_mac_clock_config_t {
+        #[cfg(not(esp_idf_version_at_least_6_0_0))]
         let rmii = match self {
             Self::Input(_) => eth_mac_clock_config_t__bindgen_ty_2 {
                 clock_mode: emac_rmii_clock_mode_t_EMAC_CLK_EXT_IN,
@@ -81,22 +112,52 @@ impl RmiiClockConfig<'_> {
             },
         };
 
+        // In v6.0, clock_gpio is a plain int (GPIO number) instead of an enum
+        #[cfg(esp_idf_version_at_least_6_0_0)]
+        let rmii = match self {
+            Self::Input(_) => eth_mac_clock_config_t__bindgen_ty_2 {
+                clock_mode: emac_rmii_clock_mode_t_EMAC_CLK_EXT_IN,
+                clock_gpio: 0,
+            },
+            Self::OutputGpio0(_) => eth_mac_clock_config_t__bindgen_ty_2 {
+                clock_mode: emac_rmii_clock_mode_t_EMAC_CLK_OUT,
+                clock_gpio: 0,
+            },
+            Self::OutputGpio16(_) => eth_mac_clock_config_t__bindgen_ty_2 {
+                clock_mode: emac_rmii_clock_mode_t_EMAC_CLK_OUT,
+                clock_gpio: 16,
+            },
+            Self::OutputInvertedGpio17(_) => eth_mac_clock_config_t__bindgen_ty_2 {
+                clock_mode: emac_rmii_clock_mode_t_EMAC_CLK_OUT,
+                clock_gpio: 17,
+            },
+        };
+
         eth_mac_clock_config_t { rmii }
     }
 }
 
 #[cfg(any(
     esp_idf_eth_spi_ethernet_dm9051,
+    esp_idf_comp_espressif__dm9051_enabled,
     esp_idf_eth_spi_ethernet_w5500,
-    esp_idf_eth_spi_ethernet_ksz8851snl
+    esp_idf_comp_espressif__w5500_enabled,
+    esp_idf_eth_spi_ethernet_ksz8851snl,
+    esp_idf_comp_espressif__ksz8851snl_enabled
 ))]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum SpiEthChipset {
-    #[cfg(esp_idf_eth_spi_ethernet_dm9051)]
+    #[cfg(any(
+        esp_idf_eth_spi_ethernet_dm9051,
+        esp_idf_comp_espressif__dm9051_enabled
+    ))]
     DM9051,
-    #[cfg(esp_idf_eth_spi_ethernet_w5500)]
+    #[cfg(any(esp_idf_eth_spi_ethernet_w5500, esp_idf_comp_espressif__w5500_enabled))]
     W5500,
-    #[cfg(esp_idf_eth_spi_ethernet_ksz8851snl)]
+    #[cfg(any(
+        esp_idf_eth_spi_ethernet_ksz8851snl,
+        esp_idf_comp_espressif__ksz8851snl_enabled
+    ))]
     KSZ8851SNL,
 }
 
@@ -117,8 +178,11 @@ pub enum SpiEthChipset {
 /// - v5.3-dev: <https://github.com/espressif/esp-idf/blob/ea010f84ef878dda07146244e166930738c1c103/components/esp_eth/include/esp_eth_mac.h#L694-L700>
 #[cfg(any(
     esp_idf_eth_spi_ethernet_dm9051,
+    esp_idf_comp_espressif__dm9051_enabled,
     esp_idf_eth_spi_ethernet_w5500,
-    esp_idf_eth_spi_ethernet_ksz8851snl
+    esp_idf_comp_espressif__w5500_enabled,
+    esp_idf_eth_spi_ethernet_ksz8851snl,
+    esp_idf_comp_espressif__ksz8851snl_enabled
 ))]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct SpiEventSource<'d> {
@@ -143,8 +207,11 @@ pub struct SpiEventSource<'d> {
 
 #[cfg(any(
     esp_idf_eth_spi_ethernet_dm9051,
+    esp_idf_comp_espressif__dm9051_enabled,
     esp_idf_eth_spi_ethernet_w5500,
-    esp_idf_eth_spi_ethernet_ksz8851snl
+    esp_idf_comp_espressif__w5500_enabled,
+    esp_idf_eth_spi_ethernet_ksz8851snl,
+    esp_idf_comp_espressif__ksz8851snl_enabled
 ))]
 impl<'d> SpiEventSource<'d> {
     /// Instead of getting informed by an interrupt pin about updates/changes from the emac, the
@@ -365,16 +432,44 @@ impl<'d> EthDriver<'d, RmiiEth> {
     ) -> Result<*mut esp_eth_phy_t, EspError> {
         let phy_cfg = Self::eth_phy_default_config(reset, phy_addr);
 
+        // In ESP-IDF v6.0+, specific PHY functions were moved to the external
+        // esp-eth-drivers component (https://github.com/espressif/esp-eth-drivers).
+        // If the component is included, use the specific function.
+        // A generic driver is always available since v5.4.0, and can be used as fallback.
         let phy = match chipset {
+            #[cfg(esp_idf_version_at_least_5_4_0)]
+            RmiiEthChipset::Generic => unsafe { esp_eth_phy_new_generic(&phy_cfg) },
+            #[cfg(any(
+                not(esp_idf_version_at_least_6_0_0),
+                esp_idf_comp_espressif__ip101_enabled
+            ))]
             RmiiEthChipset::IP101 => unsafe { esp_eth_phy_new_ip101(&phy_cfg) },
+            #[cfg(any(
+                not(esp_idf_version_at_least_6_0_0),
+                esp_idf_comp_espressif__rtl8201_enabled
+            ))]
             RmiiEthChipset::RTL8201 => unsafe { esp_eth_phy_new_rtl8201(&phy_cfg) },
+            #[cfg(any(
+                not(esp_idf_version_at_least_6_0_0),
+                esp_idf_comp_espressif__lan87xx_enabled
+            ))]
             RmiiEthChipset::LAN87XX => unsafe { esp_eth_phy_new_lan87xx(&phy_cfg) },
+            #[cfg(any(
+                not(esp_idf_version_at_least_6_0_0),
+                esp_idf_comp_espressif__dp83848_enabled
+            ))]
             RmiiEthChipset::DP83848 => unsafe { esp_eth_phy_new_dp83848(&phy_cfg) },
             #[cfg(esp_idf_version_major = "4")]
             RmiiEthChipset::KSZ8041 => unsafe { esp_eth_phy_new_ksz8041(&phy_cfg) },
             #[cfg(esp_idf_version = "4.4")]
             RmiiEthChipset::KSZ8081 => unsafe { esp_eth_phy_new_ksz8081(&phy_cfg) },
-            #[cfg(not(esp_idf_version_major = "4"))]
+            #[cfg(all(
+                not(esp_idf_version_major = "4"),
+                any(
+                    not(esp_idf_version_at_least_6_0_0),
+                    esp_idf_comp_espressif__ksz80xx_enabled
+                )
+            ))]
             RmiiEthChipset::KSZ80XX => unsafe { esp_eth_phy_new_ksz80xx(&phy_cfg) },
         };
 
@@ -432,13 +527,7 @@ impl<'d> EthDriver<'d, RmiiEth> {
         }
     }
 
-    #[cfg(not(any(
-        esp_idf_version_major = "4",
-        esp_idf_version = "5.0",
-        esp_idf_version = "5.1",
-        esp_idf_version = "5.2",
-        esp_idf_version = "5.3"
-    )))]
+    #[cfg(all(esp_idf_version_at_least_5_4_0, not(esp_idf_version_at_least_6_0_0)))]
     fn eth_esp32_emac_default_config(mdc: i32, mdio: i32) -> eth_esp32_emac_config_t {
         eth_esp32_emac_config_t {
             __bindgen_anon_1: eth_esp32_emac_config_t__bindgen_ty_1 {
@@ -446,6 +535,19 @@ impl<'d> EthDriver<'d, RmiiEth> {
                     mdc_num: mdc,
                     mdio_num: mdio,
                 },
+            },
+            interface: eth_data_interface_t_EMAC_DATA_INTERFACE_RMII,
+            ..Default::default()
+        }
+    }
+
+    // In v6.0, __bindgen_anon_1 wrapper was removed; smi_gpio is a direct field
+    #[cfg(esp_idf_version_at_least_6_0_0)]
+    fn eth_esp32_emac_default_config(mdc: i32, mdio: i32) -> eth_esp32_emac_config_t {
+        eth_esp32_emac_config_t {
+            smi_gpio: emac_esp_smi_gpio_config_t {
+                mdc_num: mdc,
+                mdio_num: mdio,
             },
             interface: eth_data_interface_t_EMAC_DATA_INTERFACE_RMII,
             ..Default::default()
@@ -480,8 +582,11 @@ impl<'d> EthDriver<'d, OpenEth> {
 
 #[cfg(any(
     esp_idf_eth_spi_ethernet_dm9051,
+    esp_idf_comp_espressif__dm9051_enabled,
     esp_idf_eth_spi_ethernet_w5500,
-    esp_idf_eth_spi_ethernet_ksz8851snl
+    esp_idf_comp_espressif__w5500_enabled,
+    esp_idf_eth_spi_ethernet_ksz8851snl,
+    esp_idf_comp_espressif__ksz8851snl_enabled
 ))]
 impl<'d, T> EthDriver<'d, SpiEth<T>>
 where
@@ -618,7 +723,10 @@ where
         let phy_cfg = Self::eth_phy_default_config(rst, phy_addr);
 
         let (mac, phy, spi_handle) = match chipset {
-            #[cfg(esp_idf_eth_spi_ethernet_dm9051)]
+            #[cfg(any(
+                esp_idf_eth_spi_ethernet_dm9051,
+                esp_idf_comp_espressif__dm9051_enabled
+            ))]
             SpiEthChipset::DM9051 => {
                 let spi_devcfg = Self::get_spi_conf(cs, 1, 7, baudrate);
 
@@ -671,7 +779,7 @@ where
 
                 (mac, phy, spi_handle)
             }
-            #[cfg(esp_idf_eth_spi_ethernet_w5500)]
+            #[cfg(any(esp_idf_eth_spi_ethernet_w5500, esp_idf_comp_espressif__w5500_enabled))]
             SpiEthChipset::W5500 => {
                 let spi_devcfg = Self::get_spi_conf(cs, 16, 8, baudrate);
 
@@ -724,7 +832,10 @@ where
 
                 (mac, phy, spi_handle)
             }
-            #[cfg(esp_idf_eth_spi_ethernet_ksz8851snl)]
+            #[cfg(any(
+                esp_idf_eth_spi_ethernet_ksz8851snl,
+                esp_idf_comp_espressif__ksz8851snl_enabled
+            ))]
             SpiEthChipset::KSZ8851SNL => {
                 let spi_devcfg = Self::get_spi_conf(cs, 0, 0, baudrate);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ pub mod log;
 pub mod mdns;
 #[cfg(all(
     feature = "alloc",
-    esp_idf_comp_mqtt_enabled,
+    any(esp_idf_comp_mqtt_enabled, esp_idf_comp_espressif__mqtt_enabled),
     esp_idf_comp_esp_event_enabled
 ))]
 pub mod mqtt;

--- a/src/log.rs
+++ b/src/log.rs
@@ -15,7 +15,7 @@ extern crate alloc;
 
 const RUST_LOG: Option<&str> = option_env!("RUST_LOG");
 
-/// Exposes the newlib stdout file descriptor to allow writing formatted
+/// Exposes the newlib/picolibc stdout file descriptor to allow writing formatted
 /// messages to stdout without a std dependency or allocation
 ///
 /// Does lock the `stdout` file descriptor on `new` and does release the lock on `drop`,
@@ -24,10 +24,14 @@ struct EspStdout(*mut FILE);
 
 impl EspStdout {
     fn new() -> Self {
-        let stdout = unsafe { __getreent().as_mut() }.unwrap()._stdout;
+        #[cfg(not(esp_idf_libc_picolibc))]
+        let stdout_ptr = unsafe { __getreent().as_mut() }.unwrap()._stdout;
+        #[cfg(esp_idf_libc_picolibc)]
+        let stdout_ptr = unsafe { stdout };
 
-        let file = unsafe { stdout.as_mut() }.unwrap();
+        let file = unsafe { stdout_ptr.as_mut() }.unwrap();
 
+        #[cfg(not(esp_idf_libc_picolibc))]
         // Copied from here:
         // https://github.com/bminor/newlib/blob/master/newlib/libc/stdio/local.h#L80
         // https://github.com/bminor/newlib/blob/3bafe2fae7a0878598a82777c623edb2faa70b74/newlib/libc/include/sys/stdio.h#L13
@@ -37,7 +41,12 @@ impl EspStdout {
             }
         }
 
-        Self(stdout)
+        #[cfg(esp_idf_libc_picolibc)]
+        unsafe {
+            _lock_acquire_recursive(&mut file.lock);
+        }
+
+        Self(stdout_ptr)
     }
 }
 
@@ -45,6 +54,7 @@ impl Drop for EspStdout {
     fn drop(&mut self) {
         let file = unsafe { self.0.as_mut() }.unwrap();
 
+        #[cfg(not(esp_idf_libc_picolibc))]
         // Copied from here:
         // https://github.com/bminor/newlib/blob/master/newlib/libc/stdio/local.h#L85
         // https://github.com/bminor/newlib/blob/3bafe2fae7a0878598a82777c623edb2faa70b74/newlib/libc/include/sys/stdio.h#L21
@@ -52,6 +62,11 @@ impl Drop for EspStdout {
             unsafe {
                 _lock_release_recursive(&mut file._lock);
             }
+        }
+
+        #[cfg(esp_idf_libc_picolibc)]
+        unsafe {
+            _lock_release_recursive(&mut file.lock);
         }
     }
 }
@@ -351,15 +366,15 @@ where
             let args = record.args();
             let color = Self::get_color(record.level());
 
-            let mut stdout = EspStdout::new();
+            let mut stdout_writer = EspStdout::new();
 
             if let Some(color) = color {
-                write!(stdout, "\x1b[0;{color}m").unwrap();
+                write!(stdout_writer, "\x1b[0;{color}m").unwrap();
             }
-            write!(stdout, "{marker} (").unwrap();
+            write!(stdout_writer, "{marker} (").unwrap();
             if cfg!(esp_idf_log_timestamp_source_rtos) {
                 let timestamp = unsafe { esp_log_timestamp() };
-                write!(stdout, "{timestamp}").unwrap();
+                write!(stdout_writer, "{timestamp}").unwrap();
             } else if cfg!(esp_idf_log_timestamp_source_system) {
                 // TODO: https://github.com/esp-rs/esp-idf-svc/pull/494 - official usage of
                 // `esp_log_timestamp_str()` should be tracked and replace the not thread-safe
@@ -367,13 +382,13 @@ where
                 // returning a pointer to a static buffer containing the c-string.
                 let timestamp =
                     unsafe { CStr::from_ptr(esp_log_system_timestamp()).to_str().unwrap() };
-                write!(stdout, "{timestamp}").unwrap();
+                write!(stdout_writer, "{timestamp}").unwrap();
             }
-            write!(stdout, ") {target}: {args}").unwrap();
+            write!(stdout_writer, ") {target}: {args}").unwrap();
             if color.is_some() {
-                write!(stdout, "\x1b[0m").unwrap();
+                write!(stdout_writer, "\x1b[0m").unwrap();
             }
-            writeln!(stdout).unwrap();
+            writeln!(stdout_writer).unwrap();
         }
     }
 

--- a/src/netif.rs
+++ b/src/netif.rs
@@ -363,6 +363,8 @@ impl EspNetif {
                     route_prio: conf.route_priority as _,
                     #[cfg(not(esp_idf_version_major = "4"))]
                     bridge_info: ptr::null_mut(),
+                    #[cfg(esp_idf_version_at_least_6_0_0)]
+                    mtu: 0,
                 },
                 match ip_conf {
                     ipv4::ClientConfiguration::DHCP(_) => None,
@@ -404,6 +406,8 @@ impl EspNetif {
                     route_prio: conf.route_priority as _,
                     #[cfg(not(esp_idf_version_major = "4"))]
                     bridge_info: ptr::null_mut(),
+                    #[cfg(esp_idf_version_at_least_6_0_0)]
+                    mtu: 0,
                 },
                 Some(esp_netif_ip_info_t {
                     ip: Newtype::<esp_ip4_addr_t>::from(ip_conf.subnet.gateway).0,
@@ -427,6 +431,8 @@ impl EspNetif {
                     route_prio: conf.route_priority as _,
                     #[cfg(not(esp_idf_version_major = "4"))]
                     bridge_info: ptr::null_mut(),
+                    #[cfg(esp_idf_version_at_least_6_0_0)]
+                    mtu: 0,
                 },
                 None,
                 false,

--- a/src/private/stubs.rs
+++ b/src/private/stubs.rs
@@ -1,6 +1,8 @@
 use core::ffi;
 
 // TODO: Figure out which library references this
+// picolibc already provides timegm, only define stub for newlib
+#[cfg(not(esp_idf_libc_picolibc))]
 #[no_mangle]
 pub extern "C" fn timegm(_: ffi::c_void) -> ffi::c_int {
     // Not supported but don't crash just in case

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1182,7 +1182,10 @@ impl<'d> WifiDriver<'d> {
         }
 
         esp!(unsafe { esp_wifi_wps_enable(&config.0 as *const _) })?;
+        #[cfg(not(esp_idf_version_at_least_6_0_0))]
         esp!(unsafe { esp_wifi_wps_start(0) })?;
+        #[cfg(esp_idf_version_at_least_6_0_0)]
+        esp!(unsafe { esp_wifi_wps_start() })?;
 
         self.status.lock().wps = None;
 


### PR DESCRIPTION
## Summary

Comprehensive ESP-IDF v6.0 API compatibility for esp-idf-svc. Purely additive -- no version bumps, no v4 removals. Incorporates all changes from @drinkcat's #650 plus original fixes.

**Companion PRs:**
- esp-idf-sys: https://github.com/esp-rs/esp-idf-sys/pull/409
- esp-idf-hal: https://github.com/esp-rs/esp-idf-hal/pull/577

### Changes

**eth:** Full v6.0 Ethernet support:
- `RmiiEthChipset::Generic` variant (v5.4+, always available in v6)
- Managed component guards for all RMII PHY drivers (IP101, RTL8201, LAN87XX, DP83848, KSZ80XX) and SPI drivers (DM9051, W5500, KSZ8851SNL)
- `clock_gpio` type change (enum -> int in v6)
- `eth_esp32_emac_config_t` SMI GPIO struct change in v6
- `SpiEthChipset` enum guards for managed components

**mqtt:** `esp_idf_comp_espressif__mqtt_enabled` guard for managed component

**log:** Picolibc-compatible EspStdout (different lock/stdout API)

**stubs:** Disable `timegm` stub for picolibc (already provided natively)

**netif:** Add `mtu` field (new in v6.0)

**wifi:** `esp_wifi_wps_start()` signature change (no args in v6)

**examples:** Updated eth and mqtt examples with v6.0 managed component documentation

**CI:** v6.0 added to test matrix, RUSTFLAGS updated

## Test plan
- [ ] CI depends on esp-idf-sys and esp-idf-hal PRs landing first