### PR TITLE
Fix "commuity" typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 **You might want to also check out the ESP IDF [Drivers](https://github.com/esp-rs/esp-idf-hal) wrappers, and the raw bindings to ESP IDF in the [esp-idf-sys](https://github.com/esp-rs/esp-idf-sys) crate!**
 
-## Commuity Effort
+## Community Effort
 
 Please note that **all `esp-idf-*` crates are a community effort**, in that Espressif puts little to no paid developer time in these.
 So while ESP-IDF itself is very popular and well tested, the `esp-idf-*` crates:


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] ~~I have updated existing examples or added new ones (if applicable).~~
- [ ] ~~I have used `cargo fmt` command to ensure that all changed code is formatted correctly.~~
- [ ] ~~I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.~~
- [ ] ~~My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.~~

Not applicable, this PR adds a single character to the README.

### Pull Request Details 📖

Same as esp-rs/esp-idf-hal#579.

#### Description
This PR simply corrects a typo in the README by changing "Commuity Effort" to "Community Effort".

#### Testing
Not applicable.