### PR TITLE
ci: add v6.0 extra remote components test matrix (using ESP_IDF_SYS_EXTRA_COMPONENTS_FILE)

### DIFF
--- a/.github/configs/extra_components_v6_eth_phy.toml
+++ b/.github/configs/extra_components_v6_eth_phy.toml
@@ -1,0 +1,18 @@
+# Ethernet PHY drivers, moved out of the ESP-IDF main tree in v6.0.
+# Only supported on esp32 and esp32p4.
+# This fragment is appended to Cargo.toml by CI when testing with remote components.
+
+[[package.metadata.esp-idf-sys.extra_components]]
+remote_component = { name = "espressif/ip101", version = "1.*" }
+
+[[package.metadata.esp-idf-sys.extra_components]]
+remote_component = { name = "espressif/lan87xx", version = "1.*" }
+
+[[package.metadata.esp-idf-sys.extra_components]]
+remote_component = { name = "espressif/dp83848", version = "1.*" }
+
+[[package.metadata.esp-idf-sys.extra_components]]
+remote_component = { name = "espressif/rtl8201", version = "1.*" }
+
+[[package.metadata.esp-idf-sys.extra_components]]
+remote_component = { name = "espressif/ksz80xx", version = "1.*" }

--- a/.github/configs/extra_components_v6_eth_spi.toml
+++ b/.github/configs/extra_components_v6_eth_spi.toml
@@ -1,0 +1,12 @@
+# Ethernet SPI drivers, moved out of the ESP-IDF main tree in v6.0.
+# Supported on all targets.
+# This fragment is appended to Cargo.toml by CI when testing with remote components.
+
+[[package.metadata.esp-idf-sys.extra_components]]
+remote_component = { name = "espressif/dm9051", version = "1.*" }
+
+[[package.metadata.esp-idf-sys.extra_components]]
+remote_component = { name = "espressif/w5500", version = "1.*" }
+
+[[package.metadata.esp-idf-sys.extra_components]]
+remote_component = { name = "espressif/ksz8851snl", version = "1.*" }

--- a/.github/configs/extra_components_v6_mqtt.toml
+++ b/.github/configs/extra_components_v6_mqtt.toml
@@ -1,0 +1,5 @@
+# MQTT component, moved out of the ESP-IDF main tree in v6.0.
+# This fragment is appended to Cargo.toml by CI when testing with remote components.
+
+[[package.metadata.esp-idf-sys.extra_components]]
+remote_component = { name = "espressif/mqtt", version = "1.*" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   compile:
-    name: Compile
+    name: "${{ matrix.target }} / ${{ matrix.idf-version }}${{ matrix.extra-components-label != '' && format(' (+{0})', matrix.extra-components-label) || '' }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -34,6 +34,29 @@ jobs:
           - v5.4.3
           - v5.5.3
           - v6.0
+        extra-components-label:
+          - ""
+        extra-components-files:
+          - ""
+        include:
+          # Also test v6.0 with remote components that were moved out of the main tree
+          # mqtt and eth SPI drivers work on all targets; eth PHY drivers only support esp32 and esp32p4
+          - target: riscv32imc-esp-espidf
+            idf-version: v6.0
+            extra-components-label: v6_mqtt
+            # We could add v6_eth_spi here, but example is esp32-only.
+            extra-components-files: ".github/configs/extra_components_v6_mqtt.toml"
+          - target: xtensa-esp32-espidf
+            idf-version: v6.0
+            extra-components-label: v6_mqtt v6_eth_spi v6_eth_phy
+            extra-components-files: ".github/configs/extra_components_v6_mqtt.toml,.github/configs/extra_components_v6_eth_spi.toml,.github/configs/extra_components_v6_eth_phy.toml"
+          # esp32p4 also supports eth, but examples are esp32-only for now
+          #- target: riscv32imafc-esp-espidf
+          #  idf-version: v6.0
+          #  extra-components-label: v6_mqtt v6_eth_spi v6_eth_phy
+          #  extra-components-files: ".github/configs/extra_components_v6_mqtt.toml,.github/configs/extra_components_v6_eth_spi.toml,.github/configs/extra_components_v6_eth_phy.toml"
+    env:
+      ESP_IDF_SYS_EXTRA_COMPONENTS_FILE: ${{ matrix.extra-components-files }}
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section. => CI change only, is this needed?

### Pull Request Details 📖

#### Description
Add CI jobs that test-build with remote components (mqtt, eth PHY/SPI
drivers) that were moved out of the ESP-IDF main tree in v6.0.
Uses ESP_IDF_SYS_EXTRA_COMPONENTS_FILE env var (new in esp-idf-sys)
to pass component TOML fragments without modifying Cargo.toml.

- riscv32imc / v6.0: mqtt only
- xtensa-esp32 / v6.0: mqtt + eth SPI + eth PHY drivers

- [x] TODO: As usual, I'll drop the esp-idf-sys pin after the https://github.com/esp-rs/esp-idf-sys/pull/411 is merged -- if we're ok with the approach that is.

#### Testing

Tested in CI, and also locally -- note that it's still not ideal, as if the components are not pulled in correctly, the build just emit an empty example...