### PR TITLE
docs: update docs.esp-rs.org links to docs.rs

### DIFF
--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1219,9 +1219,9 @@ impl<'d> WifiDriver<'d> {
     }
 
     //TODO: add safe wrappers for these three functions
-    //https://docs.esp-rs.org/esp-idf-sys/esp_idf_sys/fn.esp_wifi_set_promiscuous_ctrl_filter.html
-    //https://docs.esp-rs.org/esp-idf-sys/esp_idf_sys/fn.esp_wifi_set_promiscuous_filter.html
-    //https://docs.esp-rs.org/esp-idf-sys/esp_idf_sys/fn.esp_wifi_set_promiscuous_rx_cb.html
+    //https://docs.rs/esp-idf-sys/latest/esp_idf_sys/fn.esp_wifi_set_promiscuous_ctrl_filter.html
+    //https://docs.rs/esp-idf-sys/latest/esp_idf_sys/fn.esp_wifi_set_promiscuous_filter.html
+    //https://docs.rs/esp-idf-sys/latest/esp_idf_sys/fn.esp_wifi_set_promiscuous_rx_cb.html
 
     /// Gets the WPS status as a [`WPS Event`] and disables WPS.
     fn stop_wps(&mut self) -> Result<WpsStatus, EspError> {


### PR DESCRIPTION
The `docs.esp-rs.org` domain has expired and now points to unsafe content.
This PR rewrites the broken references (TODO comments above some unsafe wrappers) to `docs.rs/esp-idf-sys/latest/...`.

Each replacement URL was verified to resolve (HTTP 200, follows redirects) before this PR was opened.

_Auto-generated as part of a coordinated link cleanup across `esp-rs`._