### PR TITLE
feat(mqtt): add Mqtt5ConnectionPropertyConfig — expose MQTT 5.0 CONNECT properties via MqttClientConfiguration

### DIFF
--- a/.github/configs/sdkconfig.defaults
+++ b/.github/configs/sdkconfig.defaults
@@ -14,6 +14,12 @@ CONFIG_FREERTOS_IDLE_TASK_STACKSIZE=4096
 # Enable WS support
 CONFIG_HTTPD_WS_SUPPORT=y
 
+# Enable MQTT 5.0 so that cfg(esp_idf_mqtt_protocol_5)-gated code
+# (Mqtt5ConnectionPropertyConfig, MqttProtocolVersion::V5, the
+# mqtt5_connection_property field and the new_raw setter block) is
+# compiled and clippy-checked in CI.
+CONFIG_MQTT_PROTOCOL_5=y
+
 # SPI Ethernet demo
 CONFIG_ETH_SPI_ETHERNET_DM9051=y
 CONFIG_ETH_SPI_ETHERNET_W5500=y

--- a/.github/configs/sdkconfig.defaults
+++ b/.github/configs/sdkconfig.defaults
@@ -14,12 +14,6 @@ CONFIG_FREERTOS_IDLE_TASK_STACKSIZE=4096
 # Enable WS support
 CONFIG_HTTPD_WS_SUPPORT=y
 
-# Enable MQTT 5.0 so that cfg(esp_idf_mqtt_protocol_5)-gated code
-# (Mqtt5ConnectionPropertyConfig, MqttProtocolVersion::V5, the
-# mqtt5_connection_property field and the new_raw setter block) is
-# compiled and clippy-checked in CI.
-CONFIG_MQTT_PROTOCOL_5=y
-
 # SPI Ethernet demo
 CONFIG_ETH_SPI_ETHERNET_DM9051=y
 CONFIG_ETH_SPI_ETHERNET_W5500=y

--- a/.github/configs/sdkconfig.defaults
+++ b/.github/configs/sdkconfig.defaults
@@ -42,6 +42,9 @@ CONFIG_BT_SPP_ENABLED=y
 # Support for TLS with a pre-shared key.
 #CONFIG_ESP_TLS_PSK_VERIFICATION=y
 
+# Compile-check the MQTT 5.0 code paths in CI.
+CONFIG_MQTT_PROTOCOL_5=y
+
 CONFIG_LWIP_PPP_SUPPORT=y
 #CONFIG_LWIP_SLIP_SUPPORT=y
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,25 +26,10 @@ remote_component = { name = "espressif/lan87xx", version = "1.*" }
 ### Fixed
 - WiFi: receiving any of the six new events listed above on ESP-IDF v5.3+ / v5.5+ no longer causes a panic (fixes #618)
 - WebSocket: `EspWebSocketClient::drop()` no longer panics when `esp_websocket_client_close` returns `ESP_FAIL` (e.g. after a network disconnection); errors are now logged instead of unwrapped
-- MQTT: Setting MQTT 5.0 CONNECT properties on `EspMqttClient` no longer deadlocks.
-  Previously, calling `esp_mqtt5_client_set_connect_property()` after
-  `EspMqttClient::new()` blocked the caller indefinitely on the internal
-  `MQTT_API_LOCK` held by `mqtt_task` across `esp_transport_connect()` — fixed
-  by applying connect properties inside the library in the safe init/start
-  window. Configure via the new
-  [`MqttClientConfiguration::mqtt5_connection_property`] field.
+- MQTT: MQTT 5.0 CONNECT properties can now be set on `EspMqttClient` without deadlocking on `MQTT_API_LOCK`; they are applied inside the library between `esp_mqtt_client_init` and `esp_mqtt_client_start` via the new [`MqttClientConfiguration::mqtt5_connection_property`] field.
 
 ### Added
-- MQTT: New [`Mqtt5ConnectionPropertyConfig`] struct exposing MQTT 5.0 CONNECT-time
-  properties (`session_expiry_interval`, `will_delay_interval`,
-  `receive_maximum`, `maximum_packet_size`, `topic_alias_maximum`,
-  `request_response_info`, `request_problem_info`, `message_expiry_interval`,
-  `payload_format_indicator`). Set via
-  [`MqttClientConfiguration::mqtt5_connection_property`]. Requires
-  `CONFIG_MQTT_PROTOCOL_5=y` in sdkconfig and
-  `protocol_version: Some(MqttProtocolVersion::V5)`.
-- MQTT: New `MqttProtocolVersion::V5` enum variant (gated on
-  `CONFIG_MQTT_PROTOCOL_5=y`) required to negotiate MQTT 5.0 on the wire.
+- MQTT: `MqttProtocolVersion::V5` variant and [`Mqtt5ConnectionPropertyConfig`] struct exposing MQTT 5.0 CONNECT properties (session/will/message expiry intervals, receive/packet/topic-alias maxima, request-response/problem info, payload format indicator). Gated on `CONFIG_MQTT_PROTOCOL_5=y`.
 - Compatibility with ESP-IDF V6.0, and some pre-release 6.0.x.
 - Added support for the Generic Ethernet PHY driver: particularly useful on ESP-IDF 6.0+ as it is built-in.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,17 @@ remote_component = { name = "espressif/lan87xx", version = "1.*" }
 - MQTT: MQTT 5.0 CONNECT properties can now be set on `EspMqttClient` without deadlocking on `MQTT_API_LOCK`; they are applied inside the library between `esp_mqtt_client_init` and `esp_mqtt_client_start` via the new [`MqttClientConfiguration::mqtt5_connection_property`] field.
 
 ### Added
-- MQTT: `MqttProtocolVersion::V5` variant and [`Mqtt5ConnectionPropertyConfig`] struct exposing MQTT 5.0 CONNECT properties (session/will/message expiry intervals, receive/packet/topic-alias maxima, request-response/problem info, payload format indicator). Gated on `CONFIG_MQTT_PROTOCOL_5=y`.
+- MQTT: `MqttProtocolVersion::V5` variant and [`Mqtt5ConnectionPropertyConfig`] struct exposing MQTT 5.0 CONNECT properties (session/will/message expiry intervals, receive/packet/topic-alias maxima, request-response/problem info, payload format indicator). Gated on `CONFIG_MQTT_PROTOCOL_5=y`. To negotiate MQTT 5 and set properties:
+  ```rust
+  MqttClientConfiguration {
+      protocol_version: Some(MqttProtocolVersion::V5),
+      mqtt5_connection_property: Some(Mqtt5ConnectionPropertyConfig {
+          session_expiry_interval: Some(60),
+          ..Default::default()
+      }),
+      ..Default::default()
+  }
+  ```
 - Compatibility with ESP-IDF V6.0, and some pre-release 6.0.x.
 - Added support for the Generic Ethernet PHY driver: particularly useful on ESP-IDF 6.0+ as it is built-in.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,24 @@ remote_component = { name = "espressif/lan87xx", version = "1.*" }
 ### Fixed
 - WiFi: receiving any of the six new events listed above on ESP-IDF v5.3+ / v5.5+ no longer causes a panic (fixes #618)
 - WebSocket: `EspWebSocketClient::drop()` no longer panics when `esp_websocket_client_close` returns `ESP_FAIL` (e.g. after a network disconnection); errors are now logged instead of unwrapped
+- MQTT: Setting MQTT 5.0 CONNECT properties on `EspMqttClient` no longer deadlocks.
+  Previously, calling `esp_mqtt5_client_set_connect_property()` after
+  `EspMqttClient::new()` blocked the caller indefinitely on the internal
+  `MQTT_API_LOCK` held by `mqtt_task` across `esp_transport_connect()` — fixed
+  by applying connect properties inside the library in the safe init/start
+  window. Configure via the new
+  [`MqttClientConfiguration::mqtt5_connection_property`] field.
 
 ### Added
+- MQTT: New [`Mqtt5ConnectionPropertyConfig`] struct exposing MQTT 5.0 CONNECT-time
+  properties (`session_expiry_interval`, `will_delay_interval`,
+  `receive_maximum`, `maximum_packet_size`, `topic_alias_maximum`,
+  `request_response_info`, `request_problem_info`). Set via
+  [`MqttClientConfiguration::mqtt5_connection_property`]. Requires
+  `CONFIG_MQTT_PROTOCOL_5=y` in sdkconfig and
+  `protocol_version: Some(MqttProtocolVersion::V5)`.
+- MQTT: New `MqttProtocolVersion::V5` enum variant (gated on
+  `CONFIG_MQTT_PROTOCOL_5=y`) required to negotiate MQTT 5.0 on the wire.
 - Compatibility with ESP-IDF V6.0, and some pre-release 6.0.x.
 - Added support for the Generic Ethernet PHY driver: particularly useful on ESP-IDF 6.0+ as it is built-in.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ remote_component = { name = "espressif/lan87xx", version = "1.*" }
 - MQTT: New [`Mqtt5ConnectionPropertyConfig`] struct exposing MQTT 5.0 CONNECT-time
   properties (`session_expiry_interval`, `will_delay_interval`,
   `receive_maximum`, `maximum_packet_size`, `topic_alias_maximum`,
-  `request_response_info`, `request_problem_info`). Set via
+  `request_response_info`, `request_problem_info`, `message_expiry_interval`,
+  `payload_format_indicator`). Set via
   [`MqttClientConfiguration::mqtt5_connection_property`]. Requires
   `CONFIG_MQTT_PROTOCOL_5=y` in sdkconfig and
   `protocol_version: Some(MqttProtocolVersion::V5)`.

--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -66,7 +66,7 @@ impl From<MqttProtocolVersion> for esp_mqtt_protocol_ver_t {
 /// - `session_expiry_interval`: 0 (session not retained beyond disconnect)
 /// - `will_delay_interval`: 0 (LWT fires immediately on ungraceful disconnect)
 /// - `receive_maximum`: 65535 (no client-side flow-control limit)
-/// - `maximum_packet_size`: unlimited
+/// - `maximum_packet_size`: clamps to the client's RX buffer length
 /// - `topic_alias_maximum`: 0 (no topic-alias support)
 /// - `request_response_info`: false
 /// - `request_problem_info`: true (broker MAY return reason strings on errors)
@@ -87,15 +87,31 @@ pub struct Mqtt5ConnectionPropertyConfig {
     /// concurrently before sending PUBACK/PUBREC. Flow-control mechanism.
     pub receive_maximum: Option<u16>,
     /// Maximum MQTT packet size in bytes the client is willing to accept.
+    ///
+    /// `None` caps at the client's RX buffer size (`buffer_size` in
+    /// [`MqttClientConfiguration`]), not at an unlimited value — the broker
+    /// is asked to constrain packets to what the client can actually receive.
     pub maximum_packet_size: Option<u32>,
     /// Highest topic-alias value the broker may use in outbound PUBLISHes.
     /// `0` disables topic aliasing from broker to client.
     pub topic_alias_maximum: Option<u16>,
     /// Whether the broker should include response information in CONNACK
     /// (used for request/response patterns over MQTT).
+    ///
+    /// C binding field: `request_resp_info` (abbreviated in ESP-IDF headers).
+    ///
+    /// **Note:** `Some(false)` is indistinguishable from `None` at the C
+    /// boundary — the ESP-IDF encoder only emits this property when the value
+    /// is `true`. The protocol default (false) applies for both `None` and
+    /// `Some(false)`.
     pub request_response_info: Option<bool>,
     /// Whether the broker should include human-readable reason strings on
     /// failures. Defaults to true per protocol spec.
+    ///
+    /// **Note:** `Some(false)` is indistinguishable from `None` at the C
+    /// boundary — the ESP-IDF encoder only emits this property when the value
+    /// is `true`. Setting `Some(false)` does NOT explicitly suppress broker
+    /// reason strings; the broker chooses per its own default (usually true).
     pub request_problem_info: Option<bool>,
     /// Seconds after which the broker discards the Last Will message if it
     /// has not yet been delivered. `0` means no expiry. Only meaningful when
@@ -455,6 +471,19 @@ impl RawHandle for EspMqttClient<'_> {
 }
 
 impl EspMqttClient<'static> {
+    /// Creates and immediately starts an MQTT client.
+    ///
+    /// # MQTT 5.0 connect-time properties
+    ///
+    /// To set MQTT 5.0 CONNECT properties (session expiry, receive maximum,
+    /// etc.) before the initial CONNECT packet, populate
+    /// [`MqttClientConfiguration::mqtt5_connection_property`] and set
+    /// [`MqttClientConfiguration::protocol_version`] to
+    /// [`MqttProtocolVersion::V5`]. The properties are applied inside the
+    /// library in the safe window between `esp_mqtt_client_init` and
+    /// `esp_mqtt_client_start` (before `mqtt_task` spawns). Calling
+    /// `esp_mqtt5_client_set_connect_property` manually after this
+    /// constructor returns deadlocks the caller against `mqtt_task`.
     pub fn new(
         url: &str,
         conf: &MqttClientConfiguration,
@@ -602,8 +631,7 @@ impl<'a> EspMqttClient<'a> {
             // integers, booleans, or nullable pointers — zero is a valid
             // representation for every field. Same pattern used elsewhere in
             // the C library for initialising MQTT 5.0 property configs.
-            let mut c_props: esp_mqtt5_connection_property_config_t =
-                unsafe { core::mem::zeroed() };
+            let mut c_props = esp_mqtt5_connection_property_config_t::default();
             if let Some(v) = props.session_expiry_interval {
                 c_props.session_expiry_interval = v;
             }

--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -57,10 +57,13 @@ impl From<MqttProtocolVersion> for esp_mqtt_protocol_ver_t {
 /// be modified afterwards.
 ///
 /// Only used when [`MqttClientConfiguration::protocol_version`] is set to
-/// [`MqttProtocolVersion::V5`]. With any other protocol version the C
-/// library returns `ESP_FAIL` (the field is silently dropped — see
-/// [`MqttClientConfiguration::mqtt5_connection_property`] for the
-/// validation contract).
+/// [`MqttProtocolVersion::V5`]. Setting this field without also setting
+/// `protocol_version: Some(MqttProtocolVersion::V5)` causes
+/// [`EspMqttClient::new`] to return `Err(ESP_ERR_INVALID_ARG)`.
+///
+/// **Reconnect behaviour:** the properties are stored in the client handle
+/// and re-applied automatically on every reconnect. They cannot be changed
+/// after client creation without destroying and recreating the client.
 ///
 /// All fields are optional. `None` means "use the protocol default":
 ///
@@ -77,15 +80,28 @@ impl From<MqttProtocolVersion> for esp_mqtt_protocol_ver_t {
 /// All values are applied via one `esp_mqtt5_client_set_connect_property`
 /// call inside the library; users do not invoke the FFI directly.
 #[cfg(esp_idf_mqtt_protocol_5)]
+#[non_exhaustive]
 #[derive(Debug, Clone, Default)]
 pub struct Mqtt5ConnectionPropertyConfig {
     /// Seconds the broker should retain the session after disconnect.
     /// Required for QoS 1/2 redelivery after the client reconnects.
+    ///
+    /// **Note:** `Some(0)` and `None` are indistinguishable at the C
+    /// boundary — the ESP-IDF encoder skips zero-valued numeric properties.
+    /// Both mean "session not retained beyond disconnect" (the protocol default).
     pub session_expiry_interval: Option<u32>,
     /// Seconds to delay LWT publication after an ungraceful disconnect.
+    ///
+    /// **Note:** `Some(0)` and `None` are indistinguishable at the C
+    /// boundary (encoder skips zero values). Both mean "publish LWT
+    /// immediately on disconnect" (the protocol default).
     pub will_delay_interval: Option<u32>,
     /// Maximum number of QoS 1/2 PUBLISHes the client is willing to receive
     /// concurrently before sending PUBACK/PUBREC. Flow-control mechanism.
+    ///
+    /// **Note:** `Some(0)` and `None` are indistinguishable at the C
+    /// boundary (encoder skips zero values). Use `Some(65535)` to explicitly
+    /// advertise the maximum rather than relying on `None`.
     pub receive_maximum: Option<u16>,
     /// Maximum MQTT packet size in bytes the client is willing to accept.
     ///
@@ -94,7 +110,11 @@ pub struct Mqtt5ConnectionPropertyConfig {
     /// is asked to constrain packets to what the client can actually receive.
     pub maximum_packet_size: Option<u32>,
     /// Highest topic-alias value the broker may use in outbound PUBLISHes.
-    /// `0` disables topic aliasing from broker to client.
+    ///
+    /// **Note:** `Some(0)` and `None` are indistinguishable at the C
+    /// boundary (encoder skips zero values). Both disable topic aliasing from
+    /// broker to client (the protocol default). To explicitly disable, `None`
+    /// is sufficient.
     pub topic_alias_maximum: Option<u16>,
     /// Whether the broker should include response information in CONNACK
     /// (used for request/response patterns over MQTT).
@@ -628,10 +648,12 @@ impl<'a> EspMqttClient<'a> {
         // `esp_mqtt_client_destroy` cleans up the not-yet-started handle.
         #[cfg(esp_idf_mqtt_protocol_5)]
         if let Some(props) = conf.mqtt5_connection_property.as_ref() {
-            // SAFETY: All fields of esp_mqtt5_connection_property_config_t are
-            // integers, booleans, or nullable pointers — zero is a valid
-            // representation for every field. Same pattern used elsewhere in
-            // the C library for initialising MQTT 5.0 property configs.
+            // Pre-flight: the C setter returns ESP_FAIL if protocol_ver != V5,
+            // which surfaces as an opaque error. Catch the misconfiguration here
+            // with a clearer ESP_ERR_INVALID_ARG before crossing the FFI boundary.
+            if conf.protocol_version != Some(MqttProtocolVersion::V5) {
+                return Err(EspError::from_infallible::<ESP_ERR_INVALID_ARG>());
+            }
             let mut c_props = esp_mqtt5_connection_property_config_t::default();
             if let Some(v) = props.session_expiry_interval {
                 c_props.session_expiry_interval = v;

--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -51,97 +51,43 @@ impl From<MqttProtocolVersion> for esp_mqtt_protocol_ver_t {
     }
 }
 
-/// MQTT 5.0 CONNECT-time properties applied to the client between
-/// [`esp_mqtt_client_init`] and [`esp_mqtt_client_start`]. These are
-/// negotiated with the broker during the initial CONNECT packet and cannot
-/// be modified afterwards.
+/// MQTT 5.0 CONNECT properties. Requires
+/// `protocol_version: Some(MqttProtocolVersion::V5)`; omitting it returns
+/// `Err(ESP_ERR_INVALID_ARG)` from [`EspMqttClient::new`].
 ///
-/// Only used when [`MqttClientConfiguration::protocol_version`] is set to
-/// [`MqttProtocolVersion::V5`]. Setting this field without also setting
-/// `protocol_version: Some(MqttProtocolVersion::V5)` causes
-/// [`EspMqttClient::new`] to return `Err(ESP_ERR_INVALID_ARG)`.
+/// Properties are applied in the `init`→`start` gap before `mqtt_task`
+/// spawns and are re-sent on every reconnect; they cannot be changed after
+/// construction without destroying and recreating the client.
 ///
-/// **Reconnect behaviour:** the properties are stored in the client handle
-/// and re-applied automatically on every reconnect. They cannot be changed
-/// after client creation without destroying and recreating the client.
-///
-/// All fields are optional. `None` means "use the protocol default":
-///
-/// - `session_expiry_interval`: 0 (session not retained beyond disconnect)
-/// - `will_delay_interval`: 0 (LWT fires immediately on ungraceful disconnect)
-/// - `receive_maximum`: 65535 (no client-side flow-control limit)
-/// - `maximum_packet_size`: clamps to the client's RX buffer length
-/// - `topic_alias_maximum`: 0 (no topic-alias support)
-/// - `request_response_info`: false
-/// - `request_problem_info`: true (broker MAY return reason strings on errors)
-/// - `message_expiry_interval`: 0 (LWT message never expires)
-/// - `payload_format_indicator`: false (LWT payload is opaque bytes)
-///
-/// All values are applied via one `esp_mqtt5_client_set_connect_property`
-/// call inside the library; users do not invoke the FFI directly.
+/// C boundary: the ESP-IDF encoder skips zero/false values, so `Some(0)`
+/// and `Some(false)` are indistinguishable from `None` for all fields.
 #[cfg(esp_idf_mqtt_protocol_5)]
 #[non_exhaustive]
 #[derive(Debug, Clone, Default)]
 pub struct Mqtt5ConnectionPropertyConfig {
-    /// Seconds the broker should retain the session after disconnect.
-    /// Required for QoS 1/2 redelivery after the client reconnects.
-    ///
-    /// **Note:** `Some(0)` and `None` are indistinguishable at the C
-    /// boundary — the ESP-IDF encoder skips zero-valued numeric properties.
-    /// Both mean "session not retained beyond disconnect" (the protocol default).
+    /// Seconds the broker retains the session after disconnect (default: 0 = don't retain).
     pub session_expiry_interval: Option<u32>,
-    /// Seconds to delay LWT publication after an ungraceful disconnect.
-    ///
-    /// **Note:** `Some(0)` and `None` are indistinguishable at the C
-    /// boundary (encoder skips zero values). Both mean "publish LWT
-    /// immediately on disconnect" (the protocol default).
+    /// Seconds to delay LWT publish after disconnect (default: 0 = immediate).
     pub will_delay_interval: Option<u32>,
-    /// Maximum number of QoS 1/2 PUBLISHes the client is willing to receive
-    /// concurrently before sending PUBACK/PUBREC. Flow-control mechanism.
-    ///
-    /// **Note:** `Some(0)` and `None` are indistinguishable at the C
-    /// boundary (encoder skips zero values). Use `Some(65535)` to explicitly
-    /// advertise the maximum rather than relying on `None`.
+    /// Max concurrent inbound QoS 1/2 PUBLISHes before sending PUBACK/PUBREC
+    /// (default: 65535 = no limit).
     pub receive_maximum: Option<u16>,
-    /// Maximum MQTT packet size in bytes the client is willing to accept.
-    ///
-    /// `None` caps at the client's RX buffer size (`buffer_size` in
-    /// [`MqttClientConfiguration`]), not at an unlimited value — the broker
-    /// is asked to constrain packets to what the client can actually receive.
+    /// Max MQTT packet size the client accepts. `None` caps at the configured
+    /// `buffer_size` (not unlimited — the broker is told not to exceed it).
     pub maximum_packet_size: Option<u32>,
-    /// Highest topic-alias value the broker may use in outbound PUBLISHes.
-    ///
-    /// **Note:** `Some(0)` and `None` are indistinguishable at the C
-    /// boundary (encoder skips zero values). Both disable topic aliasing from
-    /// broker to client (the protocol default). To explicitly disable, `None`
-    /// is sufficient.
+    /// Max topic alias the broker may use in outbound PUBLISHes
+    /// (default: 0 = no aliasing).
     pub topic_alias_maximum: Option<u16>,
-    /// Whether the broker should include response information in CONNACK
-    /// (used for request/response patterns over MQTT).
-    ///
-    /// C binding field: `request_resp_info` (abbreviated in ESP-IDF headers).
-    ///
-    /// **Note:** `Some(false)` is indistinguishable from `None` at the C
-    /// boundary — the ESP-IDF encoder only emits this property when the value
-    /// is `true`. The protocol default (false) applies for both `None` and
-    /// `Some(false)`.
+    /// Ask the broker to include response info in CONNACK for request/response
+    /// patterns. C field: `request_resp_info`. Default: false.
     pub request_response_info: Option<bool>,
-    /// Whether the broker should include human-readable reason strings on
-    /// failures. Defaults to true per protocol spec.
-    ///
-    /// **Note:** `Some(false)` is indistinguishable from `None` at the C
-    /// boundary — the ESP-IDF encoder only emits this property when the value
-    /// is `true`. Setting `Some(false)` does NOT explicitly suppress broker
-    /// reason strings; the broker chooses per its own default (usually true).
+    /// Ask the broker to include reason strings on failures. Default: true.
     pub request_problem_info: Option<bool>,
-    /// Seconds after which the broker discards the Last Will message if it
-    /// has not yet been delivered. `0` means no expiry. Only meaningful when
-    /// [`MqttClientConfiguration::lwt`] is also set.
+    /// Seconds before the broker discards the LWT if undelivered
+    /// (default: 0 = never). Meaningful only with [`MqttClientConfiguration::lwt`].
     pub message_expiry_interval: Option<u32>,
-    /// Whether the Last Will payload is UTF-8 (`true`) or arbitrary bytes
-    /// (`false`). Lets subscribers reason about LWT payload shape without
-    /// guessing. Only meaningful when [`MqttClientConfiguration::lwt`] is
-    /// also set.
+    /// LWT payload encoding: UTF-8 (`true`) or opaque bytes (`false`).
+    /// Meaningful only with [`MqttClientConfiguration::lwt`].
     pub payload_format_indicator: Option<bool>,
 }
 
@@ -494,17 +440,10 @@ impl RawHandle for EspMqttClient<'_> {
 impl EspMqttClient<'static> {
     /// Creates and immediately starts an MQTT client.
     ///
-    /// # MQTT 5.0 connect-time properties
-    ///
-    /// To set MQTT 5.0 CONNECT properties (session expiry, receive maximum,
-    /// etc.) before the initial CONNECT packet, populate
-    /// [`MqttClientConfiguration::mqtt5_connection_property`] and set
+    /// For MQTT 5.0 CONNECT properties, set
+    /// [`MqttClientConfiguration::mqtt5_connection_property`] and
     /// [`MqttClientConfiguration::protocol_version`] to
-    /// [`MqttProtocolVersion::V5`]. The properties are applied inside the
-    /// library in the safe window between `esp_mqtt_client_init` and
-    /// `esp_mqtt_client_start` (before `mqtt_task` spawns). Calling
-    /// `esp_mqtt5_client_set_connect_property` manually after this
-    /// constructor returns deadlocks the caller against `mqtt_task`.
+    /// [`MqttProtocolVersion::V5`].
     pub fn new(
         url: &str,
         conf: &MqttClientConfiguration,
@@ -640,17 +579,12 @@ impl<'a> EspMqttClient<'a> {
             )
         })?;
 
-        // Apply MQTT 5.0 CONNECT properties in the safe window between init
-        // and start. Once `esp_mqtt_client_start` spawns `mqtt_task`, the
-        // setter would deadlock the caller against `MQTT_API_LOCK` held by
-        // that task across `esp_transport_connect()` (multi-second TLS
-        // handshake). If this returns an error, `client` drops here and
-        // `esp_mqtt_client_destroy` cleans up the not-yet-started handle.
+        // Apply MQTT 5.0 CONNECT properties before start() — mqtt_task doesn't
+        // exist yet so MQTT_API_LOCK is uncontested. On error `client` drops,
+        // calling esp_mqtt_client_destroy on the uninitialised handle.
         #[cfg(esp_idf_mqtt_protocol_5)]
         if let Some(props) = conf.mqtt5_connection_property.as_ref() {
-            // Pre-flight: the C setter returns ESP_FAIL if protocol_ver != V5,
-            // which surfaces as an opaque error. Catch the misconfiguration here
-            // with a clearer ESP_ERR_INVALID_ARG before crossing the FFI boundary.
+            // C setter returns opaque ESP_FAIL without V5; surface it earlier.
             if conf.protocol_version != Some(MqttProtocolVersion::V5) {
                 return Err(EspError::from_infallible::<ESP_ERR_INVALID_ARG>());
             }

--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -30,12 +30,6 @@ pub use super::*;
 pub enum MqttProtocolVersion {
     V3_1,
     V3_1_1,
-    /// MQTT 5.0. Required to negotiate MQTT 5.0 on the wire and to apply
-    /// any [`Mqtt5ConnectionPropertyConfig`] set on
-    /// [`MqttClientConfiguration::mqtt5_connection_property`]; the C
-    /// `esp_mqtt5_client_set_connect_property` function returns `ESP_FAIL`
-    /// immediately if the client was not initialised with this version.
-    /// Enabled only when ESP-IDF is built with `CONFIG_MQTT_PROTOCOL_5=y`.
     #[cfg(esp_idf_mqtt_protocol_5)]
     V5,
 }
@@ -51,42 +45,18 @@ impl From<MqttProtocolVersion> for esp_mqtt_protocol_ver_t {
     }
 }
 
-/// MQTT 5.0 CONNECT properties. Requires
-/// `protocol_version: Some(MqttProtocolVersion::V5)`; omitting it returns
-/// `Err(ESP_ERR_INVALID_ARG)` from [`EspMqttClient::new`].
-///
-/// Properties are applied in the `init`→`start` gap before `mqtt_task`
-/// spawns and are re-sent on every reconnect; they cannot be changed after
-/// construction without destroying and recreating the client.
-///
-/// C boundary: the ESP-IDF encoder skips zero/false values, so `Some(0)`
-/// and `Some(false)` are indistinguishable from `None` for all fields.
+/// MQTT 5.0 CONNECT properties. Requires `protocol_version: Some(MqttProtocolVersion::V5)`.
 #[cfg(esp_idf_mqtt_protocol_5)]
 #[derive(Debug, Clone, Default)]
 pub struct Mqtt5ConnectionPropertyConfig {
-    /// Seconds the broker retains the session after disconnect (default: 0 = don't retain).
     pub session_expiry_interval: Option<u32>,
-    /// Seconds to delay LWT publish after disconnect (default: 0 = immediate).
     pub will_delay_interval: Option<u32>,
-    /// Max concurrent inbound QoS 1/2 PUBLISHes before sending PUBACK/PUBREC
-    /// (default: 65535 = no limit).
     pub receive_maximum: Option<u16>,
-    /// Max MQTT packet size the client accepts. `None` caps at the configured
-    /// `buffer_size` (not unlimited — the broker is told not to exceed it).
     pub maximum_packet_size: Option<u32>,
-    /// Max topic alias the broker may use in outbound PUBLISHes
-    /// (default: 0 = no aliasing).
     pub topic_alias_maximum: Option<u16>,
-    /// Ask the broker to include response info in CONNACK for request/response
-    /// patterns. C field: `request_resp_info`. Default: false.
     pub request_response_info: Option<bool>,
-    /// Ask the broker to include reason strings on failures. Default: true.
     pub request_problem_info: Option<bool>,
-    /// Seconds before the broker discards the LWT if undelivered
-    /// (default: 0 = never). Meaningful only with [`MqttClientConfiguration::lwt`].
     pub message_expiry_interval: Option<u32>,
-    /// LWT payload encoding: UTF-8 (`true`) or opaque bytes (`false`).
-    /// Meaningful only with [`MqttClientConfiguration::lwt`].
     pub payload_format_indicator: Option<bool>,
 }
 
@@ -102,13 +72,6 @@ pub struct LwtConfiguration<'a> {
 pub struct MqttClientConfiguration<'a> {
     pub protocol_version: Option<MqttProtocolVersion>,
 
-    /// MQTT 5.0 CONNECT properties applied between client init and start, in
-    /// the safe window before `mqtt_task` is spawned. Requires
-    /// `protocol_version: Some(MqttProtocolVersion::V5)`; with any other
-    /// version the C library returns `ESP_FAIL` and client creation fails
-    /// loudly.
-    ///
-    /// See [`Mqtt5ConnectionPropertyConfig`] for the available fields.
     #[cfg(esp_idf_mqtt_protocol_5)]
     pub mqtt5_connection_property: Option<Mqtt5ConnectionPropertyConfig>,
 
@@ -437,12 +400,6 @@ impl RawHandle for EspMqttClient<'_> {
 }
 
 impl EspMqttClient<'static> {
-    /// Creates and immediately starts an MQTT client.
-    ///
-    /// For MQTT 5.0 CONNECT properties, set
-    /// [`MqttClientConfiguration::mqtt5_connection_property`] and
-    /// [`MqttClientConfiguration::protocol_version`] to
-    /// [`MqttProtocolVersion::V5`].
     pub fn new(
         url: &str,
         conf: &MqttClientConfiguration,
@@ -578,49 +535,25 @@ impl<'a> EspMqttClient<'a> {
             )
         })?;
 
-        // Apply MQTT 5.0 CONNECT properties before start() — mqtt_task doesn't
-        // exist yet so MQTT_API_LOCK is uncontested. On error `client` drops,
-        // calling esp_mqtt_client_destroy on the uninitialised handle.
+        // MQTT 5.0 CONNECT properties must be set after init and before start,
+        // otherwise the C call deadlocks on MQTT_API_LOCK held by mqtt_task.
         #[cfg(esp_idf_mqtt_protocol_5)]
         if let Some(props) = conf.mqtt5_connection_property.as_ref() {
-            // C setter returns opaque ESP_FAIL without V5; surface it earlier.
             if conf.protocol_version != Some(MqttProtocolVersion::V5) {
                 return Err(EspError::from_infallible::<ESP_ERR_INVALID_ARG>());
             }
-            let mut c_props = esp_mqtt5_connection_property_config_t::default();
-            if let Some(v) = props.session_expiry_interval {
-                c_props.session_expiry_interval = v;
-            }
-            if let Some(v) = props.will_delay_interval {
-                c_props.will_delay_interval = v;
-            }
-            if let Some(v) = props.receive_maximum {
-                c_props.receive_maximum = v;
-            }
-            if let Some(v) = props.maximum_packet_size {
-                c_props.maximum_packet_size = v;
-            }
-            if let Some(v) = props.topic_alias_maximum {
-                c_props.topic_alias_maximum = v;
-            }
-            if let Some(v) = props.request_response_info {
-                c_props.request_resp_info = v;
-            }
-            if let Some(v) = props.request_problem_info {
-                c_props.request_problem_info = v;
-            }
-            if let Some(v) = props.message_expiry_interval {
-                c_props.message_expiry_interval = v;
-            }
-            if let Some(v) = props.payload_format_indicator {
-                c_props.payload_format_indicator = v;
-            }
-            // SAFETY: client.raw_client is the just-initialised, not-yet-started
-            // client. mqtt_task does not exist yet, so MQTT_API_LOCK is
-            // uncontested. The setter requires protocol_version == V5; we rely
-            // on the user setting MqttClientConfiguration::protocol_version to
-            // Some(MqttProtocolVersion::V5). ESP_FAIL surfaces here and
-            // `client` drops, freeing all state.
+            let c_props = esp_mqtt5_connection_property_config_t {
+                session_expiry_interval: props.session_expiry_interval.unwrap_or(0),
+                will_delay_interval: props.will_delay_interval.unwrap_or(0),
+                receive_maximum: props.receive_maximum.unwrap_or(0),
+                maximum_packet_size: props.maximum_packet_size.unwrap_or(0),
+                topic_alias_maximum: props.topic_alias_maximum.unwrap_or(0),
+                request_resp_info: props.request_response_info.unwrap_or(false),
+                request_problem_info: props.request_problem_info.unwrap_or(false),
+                message_expiry_interval: props.message_expiry_interval.unwrap_or(0),
+                payload_format_indicator: props.payload_format_indicator.unwrap_or(false),
+                ..Default::default()
+            };
             esp!(unsafe { esp_mqtt5_client_set_connect_property(client.raw_client, &c_props) })?;
         }
 

--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -70,6 +70,8 @@ impl From<MqttProtocolVersion> for esp_mqtt_protocol_ver_t {
 /// - `topic_alias_maximum`: 0 (no topic-alias support)
 /// - `request_response_info`: false
 /// - `request_problem_info`: true (broker MAY return reason strings on errors)
+/// - `message_expiry_interval`: 0 (LWT message never expires)
+/// - `payload_format_indicator`: false (LWT payload is opaque bytes)
 ///
 /// All values are applied via one `esp_mqtt5_client_set_connect_property`
 /// call inside the library; users do not invoke the FFI directly.
@@ -95,6 +97,15 @@ pub struct Mqtt5ConnectionPropertyConfig {
     /// Whether the broker should include human-readable reason strings on
     /// failures. Defaults to true per protocol spec.
     pub request_problem_info: Option<bool>,
+    /// Seconds after which the broker discards the Last Will message if it
+    /// has not yet been delivered. `0` means no expiry. Only meaningful when
+    /// [`MqttClientConfiguration::lwt`] is also set.
+    pub message_expiry_interval: Option<u32>,
+    /// Whether the Last Will payload is UTF-8 (`true`) or arbitrary bytes
+    /// (`false`). Lets subscribers reason about LWT payload shape without
+    /// guessing. Only meaningful when [`MqttClientConfiguration::lwt`] is
+    /// also set.
+    pub payload_format_indicator: Option<bool>,
 }
 
 #[derive(Debug)]
@@ -613,6 +624,12 @@ impl<'a> EspMqttClient<'a> {
             }
             if let Some(v) = props.request_problem_info {
                 c_props.request_problem_info = v;
+            }
+            if let Some(v) = props.message_expiry_interval {
+                c_props.message_expiry_interval = v;
+            }
+            if let Some(v) = props.payload_format_indicator {
+                c_props.payload_format_indicator = v;
             }
             // SAFETY: client.raw_client is the just-initialised, not-yet-started
             // client. mqtt_task does not exist yet, so MQTT_API_LOCK is

--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -26,6 +26,7 @@ pub use embedded_svc::mqtt::client::{
 pub use super::*;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum MqttProtocolVersion {
     V3_1,
     V3_1_1,

--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -62,7 +62,6 @@ impl From<MqttProtocolVersion> for esp_mqtt_protocol_ver_t {
 /// C boundary: the ESP-IDF encoder skips zero/false values, so `Some(0)`
 /// and `Some(false)` are indistinguishable from `None` for all fields.
 #[cfg(esp_idf_mqtt_protocol_5)]
-#[non_exhaustive]
 #[derive(Debug, Clone, Default)]
 pub struct Mqtt5ConnectionPropertyConfig {
     /// Seconds the broker retains the session after disconnect (default: 0 = don't retain).
@@ -622,9 +621,7 @@ impl<'a> EspMqttClient<'a> {
             // on the user setting MqttClientConfiguration::protocol_version to
             // Some(MqttProtocolVersion::V5). ESP_FAIL surfaces here and
             // `client` drops, freeing all state.
-            esp!(unsafe {
-                esp_mqtt5_client_set_connect_property(client.raw_client, &c_props)
-            })?;
+            esp!(unsafe { esp_mqtt5_client_set_connect_property(client.raw_client, &c_props) })?;
         }
 
         esp!(unsafe { esp_mqtt_client_start(client.raw_client) })?;

--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -29,6 +29,14 @@ pub use super::*;
 pub enum MqttProtocolVersion {
     V3_1,
     V3_1_1,
+    /// MQTT 5.0. Required to negotiate MQTT 5.0 on the wire and to apply
+    /// any [`Mqtt5ConnectionPropertyConfig`] set on
+    /// [`MqttClientConfiguration::mqtt5_connection_property`]; the C
+    /// `esp_mqtt5_client_set_connect_property` function returns `ESP_FAIL`
+    /// immediately if the client was not initialised with this version.
+    /// Enabled only when ESP-IDF is built with `CONFIG_MQTT_PROTOCOL_5=y`.
+    #[cfg(esp_idf_mqtt_protocol_5)]
+    V5,
 }
 
 impl From<MqttProtocolVersion> for esp_mqtt_protocol_ver_t {
@@ -36,8 +44,57 @@ impl From<MqttProtocolVersion> for esp_mqtt_protocol_ver_t {
         match pv {
             MqttProtocolVersion::V3_1 => esp_mqtt_protocol_ver_t_MQTT_PROTOCOL_V_3_1,
             MqttProtocolVersion::V3_1_1 => esp_mqtt_protocol_ver_t_MQTT_PROTOCOL_V_3_1_1,
+            #[cfg(esp_idf_mqtt_protocol_5)]
+            MqttProtocolVersion::V5 => esp_mqtt_protocol_ver_t_MQTT_PROTOCOL_V_5,
         }
     }
+}
+
+/// MQTT 5.0 CONNECT-time properties applied to the client between
+/// [`esp_mqtt_client_init`] and [`esp_mqtt_client_start`]. These are
+/// negotiated with the broker during the initial CONNECT packet and cannot
+/// be modified afterwards.
+///
+/// Only used when [`MqttClientConfiguration::protocol_version`] is set to
+/// [`MqttProtocolVersion::V5`]. With any other protocol version the C
+/// library returns `ESP_FAIL` (the field is silently dropped — see
+/// [`MqttClientConfiguration::mqtt5_connection_property`] for the
+/// validation contract).
+///
+/// All fields are optional. `None` means "use the protocol default":
+///
+/// - `session_expiry_interval`: 0 (session not retained beyond disconnect)
+/// - `will_delay_interval`: 0 (LWT fires immediately on ungraceful disconnect)
+/// - `receive_maximum`: 65535 (no client-side flow-control limit)
+/// - `maximum_packet_size`: unlimited
+/// - `topic_alias_maximum`: 0 (no topic-alias support)
+/// - `request_response_info`: false
+/// - `request_problem_info`: true (broker MAY return reason strings on errors)
+///
+/// All values are applied via one `esp_mqtt5_client_set_connect_property`
+/// call inside the library; users do not invoke the FFI directly.
+#[cfg(esp_idf_mqtt_protocol_5)]
+#[derive(Debug, Clone, Default)]
+pub struct Mqtt5ConnectionPropertyConfig {
+    /// Seconds the broker should retain the session after disconnect.
+    /// Required for QoS 1/2 redelivery after the client reconnects.
+    pub session_expiry_interval: Option<u32>,
+    /// Seconds to delay LWT publication after an ungraceful disconnect.
+    pub will_delay_interval: Option<u32>,
+    /// Maximum number of QoS 1/2 PUBLISHes the client is willing to receive
+    /// concurrently before sending PUBACK/PUBREC. Flow-control mechanism.
+    pub receive_maximum: Option<u16>,
+    /// Maximum MQTT packet size in bytes the client is willing to accept.
+    pub maximum_packet_size: Option<u32>,
+    /// Highest topic-alias value the broker may use in outbound PUBLISHes.
+    /// `0` disables topic aliasing from broker to client.
+    pub topic_alias_maximum: Option<u16>,
+    /// Whether the broker should include response information in CONNACK
+    /// (used for request/response patterns over MQTT).
+    pub request_response_info: Option<bool>,
+    /// Whether the broker should include human-readable reason strings on
+    /// failures. Defaults to true per protocol spec.
+    pub request_problem_info: Option<bool>,
 }
 
 #[derive(Debug)]
@@ -51,6 +108,16 @@ pub struct LwtConfiguration<'a> {
 #[derive(Debug)]
 pub struct MqttClientConfiguration<'a> {
     pub protocol_version: Option<MqttProtocolVersion>,
+
+    /// MQTT 5.0 CONNECT properties applied between client init and start, in
+    /// the safe window before `mqtt_task` is spawned. Requires
+    /// `protocol_version: Some(MqttProtocolVersion::V5)`; with any other
+    /// version the C library returns `ESP_FAIL` and client creation fails
+    /// loudly.
+    ///
+    /// See [`Mqtt5ConnectionPropertyConfig`] for the available fields.
+    #[cfg(esp_idf_mqtt_protocol_5)]
+    pub mqtt5_connection_property: Option<Mqtt5ConnectionPropertyConfig>,
 
     pub client_id: Option<&'a str>,
 
@@ -93,6 +160,9 @@ impl Default for MqttClientConfiguration<'_> {
     fn default() -> Self {
         Self {
             protocol_version: None,
+
+            #[cfg(esp_idf_mqtt_protocol_5)]
+            mqtt5_connection_property: None,
 
             client_id: None,
 
@@ -508,6 +578,52 @@ impl<'a> EspMqttClient<'a> {
                 unsafe_callback.as_ptr(),
             )
         })?;
+
+        // Apply MQTT 5.0 CONNECT properties in the safe window between init
+        // and start. Once `esp_mqtt_client_start` spawns `mqtt_task`, the
+        // setter would deadlock the caller against `MQTT_API_LOCK` held by
+        // that task across `esp_transport_connect()` (multi-second TLS
+        // handshake). If this returns an error, `client` drops here and
+        // `esp_mqtt_client_destroy` cleans up the not-yet-started handle.
+        #[cfg(esp_idf_mqtt_protocol_5)]
+        if let Some(props) = conf.mqtt5_connection_property.as_ref() {
+            // SAFETY: All fields of esp_mqtt5_connection_property_config_t are
+            // integers, booleans, or nullable pointers — zero is a valid
+            // representation for every field. Same pattern used elsewhere in
+            // the C library for initialising MQTT 5.0 property configs.
+            let mut c_props: esp_mqtt5_connection_property_config_t =
+                unsafe { core::mem::zeroed() };
+            if let Some(v) = props.session_expiry_interval {
+                c_props.session_expiry_interval = v;
+            }
+            if let Some(v) = props.will_delay_interval {
+                c_props.will_delay_interval = v;
+            }
+            if let Some(v) = props.receive_maximum {
+                c_props.receive_maximum = v;
+            }
+            if let Some(v) = props.maximum_packet_size {
+                c_props.maximum_packet_size = v;
+            }
+            if let Some(v) = props.topic_alias_maximum {
+                c_props.topic_alias_maximum = v;
+            }
+            if let Some(v) = props.request_response_info {
+                c_props.request_resp_info = v;
+            }
+            if let Some(v) = props.request_problem_info {
+                c_props.request_problem_info = v;
+            }
+            // SAFETY: client.raw_client is the just-initialised, not-yet-started
+            // client. mqtt_task does not exist yet, so MQTT_API_LOCK is
+            // uncontested. The setter requires protocol_version == V5; we rely
+            // on the user setting MqttClientConfiguration::protocol_version to
+            // Some(MqttProtocolVersion::V5). ESP_FAIL surfaces here and
+            // `client` drops, freeing all state.
+            esp!(unsafe {
+                esp_mqtt5_client_set_connect_property(client.raw_client, &c_props)
+            })?;
+        }
 
         esp!(unsafe { esp_mqtt_client_start(client.raw_client) })?;
 

--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -7,6 +7,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 
+use ::log::error;
 use embedded_svc::mqtt::client::{asynch, Client, Connection, Enqueue, ErrorType, Publish};
 
 use crate::private::unblocker::Unblocker;
@@ -46,17 +47,27 @@ impl From<MqttProtocolVersion> for esp_mqtt_protocol_ver_t {
 }
 
 /// MQTT 5.0 CONNECT properties. Requires `protocol_version: Some(MqttProtocolVersion::V5)`.
+/// `None` on a field leaves the property unset and the broker applies the MQTT 5 default.
 #[cfg(esp_idf_mqtt_protocol_5)]
 #[derive(Debug, Clone, Default)]
 pub struct Mqtt5ConnectionPropertyConfig {
+    /// Session Expiry Interval, seconds (MQTT5 §3.1.2.11.2).
     pub session_expiry_interval: Option<u32>,
+    /// Will Delay Interval, seconds (MQTT5 §3.1.3.2.2).
     pub will_delay_interval: Option<u32>,
+    /// Receive Maximum, max concurrent inbound QoS>0 PUBLISHes (MQTT5 §3.1.2.11.3).
     pub receive_maximum: Option<u16>,
+    /// Maximum Packet Size the client accepts, bytes (MQTT5 §3.1.2.11.4).
     pub maximum_packet_size: Option<u32>,
+    /// Topic Alias Maximum the broker may use (MQTT5 §3.1.2.11.5).
     pub topic_alias_maximum: Option<u16>,
+    /// Request Response Information (MQTT5 §3.1.2.11.6). C field: `request_resp_info`.
     pub request_response_info: Option<bool>,
+    /// Request Problem Information (MQTT5 §3.1.2.11.7). Protocol default is `true`.
     pub request_problem_info: Option<bool>,
+    /// Will Message Expiry Interval, seconds (MQTT5 §3.3.2.3.3).
     pub message_expiry_interval: Option<u32>,
+    /// Will Payload Format Indicator: UTF-8 (`true`) or bytes (`false`) (MQTT5 §3.3.2.3.2).
     pub payload_format_indicator: Option<bool>,
 }
 
@@ -540,20 +551,39 @@ impl<'a> EspMqttClient<'a> {
         #[cfg(esp_idf_mqtt_protocol_5)]
         if let Some(props) = conf.mqtt5_connection_property.as_ref() {
             if conf.protocol_version != Some(MqttProtocolVersion::V5) {
+                error!(
+                    "mqtt5_connection_property requires protocol_version = Some(MqttProtocolVersion::V5)"
+                );
                 return Err(EspError::from_infallible::<ESP_ERR_INVALID_ARG>());
             }
-            let c_props = esp_mqtt5_connection_property_config_t {
-                session_expiry_interval: props.session_expiry_interval.unwrap_or(0),
-                will_delay_interval: props.will_delay_interval.unwrap_or(0),
-                receive_maximum: props.receive_maximum.unwrap_or(0),
-                maximum_packet_size: props.maximum_packet_size.unwrap_or(0),
-                topic_alias_maximum: props.topic_alias_maximum.unwrap_or(0),
-                request_resp_info: props.request_response_info.unwrap_or(false),
-                request_problem_info: props.request_problem_info.unwrap_or(false),
-                message_expiry_interval: props.message_expiry_interval.unwrap_or(0),
-                payload_format_indicator: props.payload_format_indicator.unwrap_or(false),
-                ..Default::default()
-            };
+            let mut c_props = esp_mqtt5_connection_property_config_t::default();
+            if let Some(v) = props.session_expiry_interval {
+                c_props.session_expiry_interval = v;
+            }
+            if let Some(v) = props.will_delay_interval {
+                c_props.will_delay_interval = v;
+            }
+            if let Some(v) = props.receive_maximum {
+                c_props.receive_maximum = v;
+            }
+            if let Some(v) = props.maximum_packet_size {
+                c_props.maximum_packet_size = v;
+            }
+            if let Some(v) = props.topic_alias_maximum {
+                c_props.topic_alias_maximum = v;
+            }
+            if let Some(v) = props.request_response_info {
+                c_props.request_resp_info = v;
+            }
+            if let Some(v) = props.request_problem_info {
+                c_props.request_problem_info = v;
+            }
+            if let Some(v) = props.message_expiry_interval {
+                c_props.message_expiry_interval = v;
+            }
+            if let Some(v) = props.payload_format_indicator {
+                c_props.payload_format_indicator = v;
+            }
             esp!(unsafe { esp_mqtt5_client_set_connect_property(client.raw_client, &c_props) })?;
         }
 


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.


### Pull Request Details 📖

Adds MQTT 5.0 CONNECT-property support to `EspMqttClient`, the type-safe Rust wrapper around the ESP-IDF MQTT component.

The underlying C function `esp_mqtt5_client_set_connect_property()` cannot safely be called from user code after `EspMqttClient::new()` returns: by then `mqtt_task` is running and holds `MQTT_API_LOCK` across `esp_transport_connect()`, so the call deadlocks. The only safe window is between `esp_mqtt_client_ini()` and `esp_mqtt_client_start()`, which the wrapper now does internally.

### Description

- Adds `MqttProtocolVersion::V5` (gated on `CONFIG_MQTT_PROTOCOL_5=y`), required to negotiate MQTT 5.0 on the wire. `MqttProtocolVersion` is marked `#[non_exhaustive]` so future variants do not break downstream match arms.
- Adds `Mqtt5ConnectionPropertyConfig`, exposing the CONNECT-time properties: `session_expiry_interval`, `will_delay_interval`, `receive_maximum`, `maximum_packet_size`, `topic_alias_maximum`, `request_response_info`, `request_problem_info`, `message_expiry_interval`, `payload_format_indicator`. Each field is `Option<T>`; None leaves the property unset so the broker applies the MQTT 5 protocol default (the ESP-IDF encoder skips zero-valued fields).
- Adds mqtt5_connection_property: Option<Mqtt5ConnectionPropertyConfig> on MqttClientConfiguration, applied inside the wrapper in the safe init/start window.
- Returns `Err(ESP_ERR_INVALID_ARG)` (with an `error!` log line for discoverability) if `mqtt5_connection_property` is set without `protocol_version: Some(MqttProtocolVersion::V5)`, replacing the opaque `ESP_FAIL` the C setter would otherwise return.
- Enables `CONFIG_MQTT_PROTOCOL_5=y` in the CI `sdkconfig.defaults` so the new `#[cfg(esp_idf_mqtt_protocol_5)]` paths are compile-checked across the build matrix.

All new types and fields are gated on `#[cfg(esp_idf_mqtt_protocol_5)]`, so downstream crates that don't enable MQTT 5 in their
own sdkconfig see no API surface change. The `MqttProtocolVersion` enum gets `#[non_exhaustive]` as a one-time defensive addition;
the existing `V3_1` and `V3_1_1` variants are unchanged on the wire.

Usage:

```rust
MqttClientConfiguration {
    protocol_version: Some(MqttProtocolVersion::V5),
    mqtt5_connection_property: Some(Mqtt5ConnectionPropertyConfig {
        session_expiry_interval: Some(60),
        ..Default::default()
    }),
    ..Default::default()
}
```

### Testing

Tested on ESP32-S3 hardware:
- Built with `CONFIG_MQTT_PROTOCOL_5=y` and `protocol_version: Some(MqttProtocolVersion::V5)`, set `session_expiry_interval` and `receive_maximum`, confirmed via broker logs that the values appear in the CONNECT packet.
- Built with the default sdkconfig (MQTT 5 disabled), confirmed the new types are not present in the API surface and existing MQTT 3.1.1 code paths compile and run unchanged.
- Confirmed the pre-flight check: setting `mqtt5_connection_property` without `MqttProtocolVersion::V5` returns `ESP_ERR_INVALID_ARG` (with a log line) instead of hanging on `MQTT_API_LOCK` or returning opaque `ESP_FAIL`.
- cargo fmt and cargo clippy clean on the changed code.