### PR TITLE
feature: bt classic a2dp sink external codec api bindings

### DIFF
--- a/.github/configs/sdkconfig.a2dp_external_codec
+++ b/.github/configs/sdkconfig.a2dp_external_codec
@@ -1,0 +1,44 @@
+# Self-contained sdkconfig fragment for the bt_a2dp_sink_external_codec example.
+# Can be used alone (`ESP_IDF_SDKCONFIG_DEFAULTS=this_file`) OR layered
+# on top of .github/configs/sdkconfig.defaults.
+
+# Stack sizes that Rust applications generally want bumped from defaults.
+CONFIG_ESP_TIMER_TASK_STACK_SIZE=4096
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=20000
+CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=8192
+CONFIG_PTHREAD_TASK_STACK_SIZE_DEFAULT=8192
+CONFIG_FREERTOS_IDLE_TASK_STACKSIZE=4096
+
+# Bluetooth Classic + Bluedroid (A2DP sink prerequisites).
+CONFIG_BT_ENABLED=y
+CONFIG_BT_BLUEDROID_ENABLED=y
+CONFIG_BT_CLASSIC_ENABLED=y
+# Disable the BLE host stack entirely. We've added a cfg gate to
+# esp-idf-svc's `bt::ble` module (src/bt.rs) so it only compiles when
+# CONFIG_BT_BLE_ENABLED=y, which sidesteps the BLE GATT bindings that
+# changed in esp-idf v6.1-dev.
+CONFIG_BT_BLE_ENABLED=n
+CONFIG_BTDM_CTRL_MODE_BR_EDR_ONLY=y
+CONFIG_BTDM_CTRL_MODE_BLE_ONLY=n
+CONFIG_BTDM_CTRL_MODE_BTDM=n
+CONFIG_BT_BTC_TASK_STACK_SIZE=15000
+
+# A2DP sink in external-codec mode with AAC + SBC SEPs.
+CONFIG_BT_A2DP_ENABLE=y
+CONFIG_BT_A2DP_USE_EXTERNAL_CODEC=y
+CONFIG_BT_A2DP_CODEC_AAC_ENABLED=y
+CONFIG_BT_A2DP_SEP_NUM_MAX=2
+
+# ESP32-WROVER (8 MB QSPI PSRAM). Bluedroid + A2DP wants more
+# heap than the bare 320 KiB internal SRAM gives.
+CONFIG_SPIRAM=y
+CONFIG_SPIRAM_MODE_QUAD=y
+CONFIG_SPIRAM_TYPE_AUTO=y
+CONFIG_SPIRAM_SPEED_80M=y
+# Flash and PSRAM share the SPI bus, so the two clock speeds must match.
+CONFIG_ESPTOOLPY_FLASHFREQ_80M=y
+CONFIG_SPIRAM_BOOT_INIT=y
+CONFIG_SPIRAM_USE_MALLOC=y
+CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP=y
+CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=16384
+CONFIG_BT_ALLOCATION_FROM_SPIRAM_FIRST=y

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ remote_component = { name = "espressif/lan87xx", version = "1.*" }
 ### Added
 - Compatibility with ESP-IDF V6.0, and some pre-release 6.0.x.
 - Added support for the Generic Ethernet PHY driver: particularly useful on ESP-IDF 6.0+ as it is built-in.
+- Added support for Bluetooth A2DP External Codec API in esp-idf v6.1 (w/ AAC codec negotiation)
 
 ## [0.52.1] - 2026-03-10
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,10 @@ log = { version = "0.4", default-features = false }
 uncased = { version = "0.9.7", default-features = false }
 embedded-hal-async = { version = "1", default-features = false }
 embedded-svc = { version = "0.29", default-features = false }
-esp-idf-hal = { version = "0.46.1", default-features = false, features = ["pcnt-legacy"] }
-embassy-time-driver = { version = "0.2.1", optional = true, features = ["tick-hz-1_000_000"] }
+esp-idf-hal = { version = "0.46.1", default-features = false }
+embassy-time-driver = { version = "0.2.1", optional = true, features = [
+    "tick-hz-1_000_000",
+] }
 embassy-time-queue-utils = { version = "0.3", optional = true }
 embassy-futures = "0.1.2"
 embedded-storage = { version = "0.3", optional = true }
@@ -74,4 +76,4 @@ async-io = "2"
 [patch.crates-io]
 esp-idf-sys = { git = "https://github.com/esp-rs/esp-idf-sys", branch = "master" }
 esp-idf-hal = { git = "https://github.com/esp-rs/esp-idf-hal", branch = "master" }
-embuild = { git = "https://github.com/esp-rs/embuild", branch = "master" } # IDF >6.0.0 strictly
+embuild = { git = "https://github.com/esp-rs/embuild", branch = "master" }         # IDF >6.0.0 strictly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ log = { version = "0.4", default-features = false }
 uncased = { version = "0.9.7", default-features = false }
 embedded-hal-async = { version = "1", default-features = false }
 embedded-svc = { version = "0.29", default-features = false }
-esp-idf-hal = { version = "0.46.1", default-features = false }
+esp-idf-hal = { version = "0.46.1", default-features = false, features = ["pcnt-legacy"] }
 embassy-time-driver = { version = "0.2.1", optional = true, features = ["tick-hz-1_000_000"] }
 embassy-time-queue-utils = { version = "0.3", optional = true }
 embassy-futures = "0.1.2"

--- a/espflash.toml
+++ b/espflash.toml
@@ -1,1 +1,2 @@
+[idf_format_args]
 partition_table = "partitions.csv"

--- a/examples/bt_a2dp_sink_external_codec.rs
+++ b/examples/bt_a2dp_sink_external_codec.rs
@@ -52,9 +52,6 @@ mod example {
     use log::info;
 
     pub fn main() -> anyhow::Result<()> {
-        // step 0 must use println! — runs BEFORE EspLogger::initialize_default(),
-        // so the `log` crate has no backend yet and `info!` would be a no-op.
-        println!("step 0: entered example::main");
         esp_idf_svc::sys::link_patches();
         EspLogger::initialize_default();
         info!("step 1: logger up");

--- a/examples/bt_a2dp_sink_external_codec.rs
+++ b/examples/bt_a2dp_sink_external_codec.rs
@@ -1,0 +1,116 @@
+//! A2DP sink example using the external-codec API.
+//!
+//! Initialises Bluedroid classic, advertises the device as A2DP sink with
+//! both AAC and SBC stream endpoints, and logs incoming events including
+//! the encoded audio buffers delivered by the peer source (typically a
+//! phone). Decoding of those buffers is intentionally left out — pair this
+//! with Espressif's `esp_audio_codec` managed component (or any other
+//! decoder) on top.
+//!
+//! Required sdkconfig settings:
+//!
+//! ```ignore
+//! CONFIG_BT_ENABLED=y
+//! CONFIG_BT_BLUEDROID_ENABLED=y
+//! CONFIG_BT_CLASSIC_ENABLED=y
+//! CONFIG_BT_A2DP_ENABLE=y
+//! CONFIG_BT_A2DP_USE_EXTERNAL_CODEC=y
+//! CONFIG_BT_A2DP_CODEC_AAC_ENABLED=y
+//! CONFIG_BT_A2DP_SEP_NUM_MAX=2
+//! CONFIG_BTDM_CTRL_MODE_BR_EDR_ONLY=y
+//! CONFIG_BTDM_CTRL_MODE_BLE_ONLY=n
+//! CONFIG_BTDM_CTRL_MODE_BTDM=n
+//! CONFIG_BT_BTC_TASK_STACK_SIZE=15000
+//! ```
+
+#![allow(unknown_lints)]
+#![allow(unexpected_cfgs)]
+
+#[cfg(all(esp32, esp_idf_bt_a2dp_use_external_codec))]
+fn main() -> anyhow::Result<()> {
+    example::main()
+}
+
+#[cfg(not(all(esp32, esp_idf_bt_a2dp_use_external_codec)))]
+fn main() -> anyhow::Result<()> {
+    println!("FALLBACK MAIN: cfg gate did not match");
+    panic!("This example requires ESP32 with CONFIG_BT_A2DP_USE_EXTERNAL_CODEC=y");
+}
+
+#[cfg(all(esp32, esp_idf_bt_a2dp_use_external_codec))]
+mod example {
+    use std::sync::Arc;
+
+    use esp_idf_svc::bt::a2dp::{A2dpEvent, Codec, EspA2dp, Sink};
+    use esp_idf_svc::bt::gap::{DiscoveryMode, EspGap};
+    use esp_idf_svc::bt::{reduce_bt_memory, BtClassic, BtDriver};
+    use esp_idf_svc::hal::delay::FreeRtos;
+    use esp_idf_svc::hal::peripherals::Peripherals;
+    use esp_idf_svc::log::EspLogger;
+    use esp_idf_svc::nvs::EspDefaultNvsPartition;
+
+    use log::info;
+
+    pub fn main() -> anyhow::Result<()> {
+        // step 0 must use println! — runs BEFORE EspLogger::initialize_default(),
+        // so the `log` crate has no backend yet and `info!` would be a no-op.
+        println!("step 0: entered example::main");
+        esp_idf_svc::sys::link_patches();
+        EspLogger::initialize_default();
+        info!("step 1: logger up");
+
+        let peripherals = Peripherals::take()?;
+        info!("step 2: peripherals taken");
+        let nvs = EspDefaultNvsPartition::take()?;
+        info!("step 3: nvs taken");
+
+        let mut modem = peripherals.modem;
+
+        reduce_bt_memory(unsafe { modem.reborrow() })?;
+        info!("step 4: reduce_bt_memory ok");
+
+        let bt = Arc::new(BtDriver::<BtClassic>::new(modem, Some(nvs.clone()))?);
+        info!("step 5: BtDriver up");
+
+        let gap = EspGap::new(bt.clone())?;
+        info!("step 6: gap created");
+        gap.set_device_name("ESP32_A2DP_SINK")?;
+        gap.set_scan_mode(true, DiscoveryMode::Discoverable)?;
+        info!("step 7: gap configured");
+
+        let a2dp = EspA2dp::<'_, _, _, Sink>::new_external_codec(bt.clone())?;
+        info!("step 8: a2dp external-codec sink up");
+
+        a2dp.subscribe(|event| {
+            match &event {
+                A2dpEvent::SinkAudioData(buf) => {
+                    info!(
+                        "audio frame: {} frames, {} bytes, ts {}",
+                        buf.frames(),
+                        buf.data().len(),
+                        buf.timestamp()
+                    );
+                }
+                A2dpEvent::SinkEndpointRegistered { seid, state } => {
+                    info!("SEP {seid} register result: {state:?}");
+                }
+                A2dpEvent::AudioCodecConfigured { bd_addr, codec } => {
+                    info!("negotiated codec with {bd_addr:?}: {codec:?}");
+                }
+                other => info!("a2dp event: {other:?}"),
+            }
+            0
+        })?;
+
+        info!("step 9: subscribed; registering SEPs");
+        // AAC at seid 0 (preferred), SBC at seid 1 (mandatory fallback).
+        a2dp.register_sink_endpoint(0, &Codec::aac_default())?;
+        a2dp.register_sink_endpoint(1, &Codec::sbc_default())?;
+
+        info!("step 10: A2DP sink ready; pair with phone and play audio");
+
+        loop {
+            FreeRtos::delay_ms(10_000);
+        }
+    }
+}

--- a/examples/bt_a2dp_sink_external_codec.rs
+++ b/examples/bt_a2dp_sink_external_codec.rs
@@ -104,8 +104,10 @@ mod example {
 
         info!("step 9: subscribed; registering SEPs");
         // AAC at seid 0 (preferred), SBC at seid 1 (mandatory fallback).
-        a2dp.register_sink_endpoint(0, &Codec::aac_default())?;
-        a2dp.register_sink_endpoint(1, &Codec::sbc_default())?;
+        for (seid, codec) in [(0, Codec::aac_default()), (1, Codec::sbc_default())] {
+            info!("registering {} at seid {}", codec.name(), seid);
+            a2dp.register_sink_endpoint(seid, &codec)?;
+        }
 
         info!("step 10: A2DP sink ready; pair with phone and play audio");
 

--- a/examples/bt_a2dp_sink_external_codec.rs
+++ b/examples/bt_a2dp_sink_external_codec.rs
@@ -15,13 +15,15 @@
 //! CONFIG_BT_CLASSIC_ENABLED=y
 //! CONFIG_BT_A2DP_ENABLE=y
 //! CONFIG_BT_A2DP_USE_EXTERNAL_CODEC=y
-//! CONFIG_BT_A2DP_CODEC_AAC_ENABLED=y
 //! CONFIG_BT_A2DP_SEP_NUM_MAX=2
 //! CONFIG_BTDM_CTRL_MODE_BR_EDR_ONLY=y
 //! CONFIG_BTDM_CTRL_MODE_BLE_ONLY=n
 //! CONFIG_BTDM_CTRL_MODE_BTDM=n
 //! CONFIG_BT_BTC_TASK_STACK_SIZE=15000
 //! ```
+//!
+//! To run this example:
+//! MCU=esp32 ESP_IDF_SDKCONFIG_DEFAULTS=.github/configs/sdkconfig.a2dp_external_codec cargo +esp espflash flash --target xtensa-esp32-espidf --example bt_a2dp_sink_external_codec --monitor
 
 #![allow(unknown_lints)]
 #![allow(unexpected_cfgs)]

--- a/src/bt.rs
+++ b/src/bt.rs
@@ -24,6 +24,7 @@ extern crate alloc;
 pub mod a2dp;
 #[cfg(all(esp32, esp_idf_bt_classic_enabled, esp_idf_bt_a2dp_enable))]
 pub mod avrc;
+#[cfg(esp_idf_bt_ble_enabled)]
 pub mod ble;
 #[cfg(all(esp32, esp_idf_bt_classic_enabled))]
 pub mod gap;

--- a/src/bt/a2dp.rs
+++ b/src/bt/a2dp.rs
@@ -76,30 +76,61 @@ pub enum Codec {
 }
 
 impl Codec {
+    /// Negotiated audio sample rate (not bitrate — the method name is kept for
+    /// API stability).
     pub fn bitrate(&self) -> Option<u32> {
-        if let Self::Sbc(data) = self {
-            let oct0 = data[0];
-            let sample_rate = if (oct0 & (0x01 << 6)) != 0 {
-                32000
-            } else if (oct0 & (0x01 << 5)) != 0 {
-                44100
-            } else if (oct0 & (0x01 << 4)) != 0 {
-                48000
-            } else {
-                16000
-            };
-
-            Some(sample_rate)
-        } else {
-            None
+        match self {
+            Self::Sbc(data) => {
+                let oct0 = data[0];
+                Some(if (oct0 & (0x01 << 6)) != 0 {
+                    32000
+                } else if (oct0 & (0x01 << 5)) != 0 {
+                    44100
+                } else if (oct0 & (0x01 << 4)) != 0 {
+                    48000
+                } else {
+                    16000
+                })
+            }
+            Self::Mpeg2_4(data) => {
+                // AAC sample-frequency bitmap (AVDTP A2DP 4.5.2):
+                // byte 1 covers 8 kHz..44.1 kHz, byte 2 high nibble covers 48..96 kHz.
+                // After negotiation exactly one bit is set.
+                if data[2] & 0x80 != 0 { Some(48000) }
+                else if data[1] & 0x01 != 0 { Some(44100) }
+                else if data[1] & 0x02 != 0 { Some(32000) }
+                else if data[1] & 0x04 != 0 { Some(24000) }
+                else if data[1] & 0x08 != 0 { Some(22050) }
+                else if data[1] & 0x10 != 0 { Some(16000) }
+                else if data[1] & 0x20 != 0 { Some(12000) }
+                else if data[1] & 0x40 != 0 { Some(11025) }
+                else if data[1] & 0x80 != 0 { Some(8000) }
+                else if data[2] & 0x40 != 0 { Some(64000) }
+                else if data[2] & 0x20 != 0 { Some(88200) }
+                else if data[2] & 0x10 != 0 { Some(96000) }
+                else { None }
+            }
+            _ => None,
         }
     }
 
     pub fn stereo(&self) -> Option<bool> {
-        if let Self::Sbc(data) = self {
-            Some((data[0] & (0x01 << 3)) == 0)
-        } else {
-            None
+        match self {
+            Self::Sbc(data) => Some((data[0] & (0x01 << 3)) == 0),
+            // AAC byte 2 bit 2 = 2-channel mode (stereo); bit 3 = 1-channel (mono).
+            Self::Mpeg2_4(data) => Some((data[2] & 0x04) != 0),
+            _ => None,
+        }
+    }
+
+    /// Short codec name for display.
+    pub const fn name(&self) -> &'static str {
+        match self {
+            Self::Sbc(_) => "SBC",
+            Self::Mpeg1_2(_) => "MPEG-1/2 Audio",
+            Self::Mpeg2_4(_) => "AAC",
+            Self::Atrac(_) => "ATRAC",
+            Self::Unknown => "Unknown",
         }
     }
 

--- a/src/bt/a2dp.rs
+++ b/src/bt/a2dp.rs
@@ -4,6 +4,10 @@ use core::borrow::Borrow;
 use core::convert::TryInto;
 use core::fmt::{self, Debug};
 use core::marker::PhantomData;
+#[cfg(esp_idf_bt_a2dp_use_external_codec)]
+use core::mem::MaybeUninit;
+#[cfg(esp_idf_bt_a2dp_use_external_codec)]
+use core::ptr::NonNull;
 
 use ::log::{info, trace};
 
@@ -98,6 +102,51 @@ impl Codec {
             None
         }
     }
+
+    /// SBC capability that advertises every common parameter combination
+    /// (all sample frequencies, all channel modes, all block lengths, all
+    /// subbands, all allocation methods, bitpool 2..=250). Matches the
+    /// in-stack default `bta_av_co_sbc_sink_caps`.
+    #[cfg(esp_idf_bt_a2dp_use_external_codec)]
+    pub fn sbc_default() -> Self {
+        Self::Sbc([0xFF, 0xFF, 2, 250])
+    }
+
+    /// AAC capability advertising MPEG-2/4 AAC LC, 44.1 + 48 kHz, stereo,
+    /// VBR up to 256 kbps. Matches what mainstream phones source.
+    #[cfg(esp_idf_bt_a2dp_use_external_codec)]
+    pub fn aac_default() -> Self {
+        // byte 0: MPEG-2 AAC LC (bit 7) + MPEG-4 AAC LC (bit 6)
+        // byte 1: 44.1 kHz (bit 0)
+        // byte 2: 48 kHz (bit 7) + stereo (bit 2)
+        // bytes 3..6: VBR=1, max bitrate = 256 kbps (0x3E800)
+        Self::Mpeg2_4([0xC0, 0x01, 0x84, 0x83, 0xE8, 0x00])
+    }
+
+    /// Build a raw `esp_a2d_mcc_t` from this codec for passing to
+    /// `esp_a2d_sink_register_stream_endpoint`. Returns `ESP_ERR_INVALID_ARG`
+    /// for `Unknown` or codecs not yet implemented (M12, ATRAC).
+    #[cfg(esp_idf_bt_a2dp_use_external_codec)]
+    pub fn to_raw_mcc(&self) -> Result<esp_a2d_mcc_t, EspError> {
+        let mut mcc = MaybeUninit::<esp_a2d_mcc_t>::zeroed();
+        // Safety: zeroed is a valid bit-pattern for esp_a2d_mcc_t (a u8 tag
+        // plus a union of byte arrays). We then write the active variant.
+        unsafe {
+            let m = &mut *mcc.as_mut_ptr();
+            match self {
+                Self::Sbc(bytes) => {
+                    m.type_ = ESP_A2D_MCT_SBC as _;
+                    m.cie.sbc_info = core::mem::transmute(*bytes);
+                }
+                Self::Mpeg2_4(bytes) => {
+                    m.type_ = ESP_A2D_MCT_M24 as _;
+                    m.cie.m24_info = core::mem::transmute(*bytes);
+                }
+                _ => return Err(EspError::from_infallible::<ESP_ERR_INVALID_ARG>()),
+            }
+            Ok(mcc.assume_init())
+        }
+    }
 }
 
 impl Debug for Codec {
@@ -131,7 +180,24 @@ pub enum ConnectionStatus {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, TryFromPrimitive)]
 #[repr(u32)]
 pub enum AudioStatus {
+    // The C enum dropped REMOTE_SUSPEND in favour of plain SUSPEND in
+    // esp-idf >= 5.2; the Rust variant name is kept stable for API users.
+    #[cfg(any(
+        esp_idf_version_major = "4",
+        all(
+            esp_idf_version_major = "5",
+            any(esp_idf_version_minor = "0", esp_idf_version_minor = "1")
+        ),
+    ))]
     SuspendedByRemote = esp_a2d_audio_state_t_ESP_A2D_AUDIO_STATE_REMOTE_SUSPEND,
+    #[cfg(not(any(
+        esp_idf_version_major = "4",
+        all(
+            esp_idf_version_major = "5",
+            any(esp_idf_version_minor = "0", esp_idf_version_minor = "1")
+        ),
+    )))]
+    SuspendedByRemote = esp_a2d_audio_state_t_ESP_A2D_AUDIO_STATE_SUSPEND,
     #[cfg(any(
         esp_idf_version_major = "4",
         all(
@@ -149,6 +215,14 @@ pub enum MediaControlCommand {
     None = esp_a2d_media_ctrl_t_ESP_A2D_MEDIA_CTRL_NONE,
     CheckSourceReady = esp_a2d_media_ctrl_t_ESP_A2D_MEDIA_CTRL_CHECK_SRC_RDY,
     Start = esp_a2d_media_ctrl_t_ESP_A2D_MEDIA_CTRL_START,
+    // STOP was dropped in esp-idf >= 5.2.
+    #[cfg(any(
+        esp_idf_version_major = "4",
+        all(
+            esp_idf_version_major = "5",
+            any(esp_idf_version_minor = "0", esp_idf_version_minor = "1")
+        ),
+    ))]
     Stop = esp_a2d_media_ctrl_t_ESP_A2D_MEDIA_CTRL_STOP,
     Suspend = esp_a2d_media_ctrl_t_ESP_A2D_MEDIA_CTRL_SUSPEND,
 }
@@ -160,6 +234,71 @@ pub enum MediaControlStatus {
     Failure = esp_a2d_media_ctrl_ack_t_ESP_A2D_MEDIA_CTRL_ACK_FAILURE,
     Busy = esp_a2d_media_ctrl_ack_t_ESP_A2D_MEDIA_CTRL_ACK_BUSY,
 }
+
+#[cfg(esp_idf_bt_a2dp_use_external_codec)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, TryFromPrimitive)]
+#[repr(u32)]
+pub enum SepRegState {
+    Success = esp_a2d_sep_reg_state_t_ESP_A2D_SEP_REG_SUCCESS,
+    Fail = esp_a2d_sep_reg_state_t_ESP_A2D_SEP_REG_FAIL,
+    Unsupported = esp_a2d_sep_reg_state_t_ESP_A2D_SEP_REG_UNSUPPORTED,
+    InvalidState = esp_a2d_sep_reg_state_t_ESP_A2D_SEP_REG_INVALID_STATE,
+}
+
+/// Owned wrapper around a Bluedroid-allocated audio buffer delivered to
+/// the sink in external-codec mode. The buffer carries the raw, undecoded
+/// AVDTP media payload — the application is responsible for decoding it
+/// (typically via `esp_audio_codec`).
+///
+/// The underlying buffer is released back to Bluedroid when this value is
+/// dropped, so callers can move it into a queue/channel for off-task
+/// decoding without worrying about manual frees.
+#[cfg(esp_idf_bt_a2dp_use_external_codec)]
+pub struct A2dpAudioBuf(NonNull<esp_a2d_audio_buff_t>);
+
+#[cfg(esp_idf_bt_a2dp_use_external_codec)]
+impl A2dpAudioBuf {
+    /// Number of encoded frames contained in this buffer.
+    pub fn frames(&self) -> u16 {
+        unsafe { (*self.0.as_ptr()).number_frame }
+    }
+
+    /// AVDTP RTP timestamp of the first frame.
+    pub fn timestamp(&self) -> u32 {
+        unsafe { (*self.0.as_ptr()).timestamp }
+    }
+
+    /// View of the encoded audio payload.
+    pub fn data(&self) -> &[u8] {
+        unsafe {
+            let raw = self.0.as_ptr();
+            core::slice::from_raw_parts((*raw).data, (*raw).data_len as usize)
+        }
+    }
+}
+
+#[cfg(esp_idf_bt_a2dp_use_external_codec)]
+impl Debug for A2dpAudioBuf {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("A2dpAudioBuf")
+            .field("frames", &self.frames())
+            .field("timestamp", &self.timestamp())
+            .field("len", &self.data().len())
+            .finish()
+    }
+}
+
+#[cfg(esp_idf_bt_a2dp_use_external_codec)]
+impl Drop for A2dpAudioBuf {
+    fn drop(&mut self) {
+        unsafe { esp_a2d_audio_buff_free(self.0.as_ptr()) };
+    }
+}
+
+// Safety: the buffer pointer is only ever touched through the wrapper, and
+// Bluedroid hands ownership over by value to the audio_data callback.
+#[cfg(esp_idf_bt_a2dp_use_external_codec)]
+unsafe impl Send for A2dpAudioBuf {}
 
 pub struct EventRawData<'a>(pub &'a esp_a2d_cb_param_t);
 
@@ -203,6 +342,12 @@ pub enum A2dpEvent<'a> {
     SourceDelay(u16),
     SinkData(&'a [u8]),
     SourceData(&'a mut [u8]),
+    /// Undecoded sink audio frames delivered in external-codec mode.
+    #[cfg(esp_idf_bt_a2dp_use_external_codec)]
+    SinkAudioData(A2dpAudioBuf),
+    /// Result of a prior `register_sink_endpoint` call.
+    #[cfg(esp_idf_bt_a2dp_use_external_codec)]
+    SinkEndpointRegistered { seid: u8, state: SepRegState },
     Other {
         raw_event: esp_a2d_cb_event_t,
         raw_data: EventRawData<'a>,
@@ -229,10 +374,21 @@ impl<'a> From<(esp_a2d_cb_event_t, &'a esp_a2d_cb_param_t)> for A2dpEvent<'a> {
                 esp_a2d_cb_event_t_ESP_A2D_AUDIO_CFG_EVT => Self::AudioCodecConfigured {
                     bd_addr: param.audio_cfg.remote_bda.into(),
                     codec: match param.audio_cfg.mcc.type_ as u32 {
-                        ESP_A2D_MCT_SBC => Codec::Sbc(param.audio_cfg.mcc.cie.sbc),
-                        ESP_A2D_MCT_M12 => Codec::Mpeg1_2(param.audio_cfg.mcc.cie.m12),
-                        ESP_A2D_MCT_M24 => Codec::Mpeg2_4(param.audio_cfg.mcc.cie.m24),
-                        ESP_A2D_MCT_ATRAC => Codec::Atrac(param.audio_cfg.mcc.cie.atrac),
+                        // The cie.*_info union members are #[repr(C, packed)] bindgen
+                        // structs whose layout is byte-identical to the corresponding
+                        // [u8; N] wire form, so we transmute to expose the raw bytes.
+                        ESP_A2D_MCT_SBC => {
+                            Codec::Sbc(core::mem::transmute(param.audio_cfg.mcc.cie.sbc_info))
+                        }
+                        ESP_A2D_MCT_M12 => {
+                            Codec::Mpeg1_2(core::mem::transmute(param.audio_cfg.mcc.cie.m12_info))
+                        }
+                        ESP_A2D_MCT_M24 => {
+                            Codec::Mpeg2_4(core::mem::transmute(param.audio_cfg.mcc.cie.m24_info))
+                        }
+                        ESP_A2D_MCT_ATRAC => {
+                            Codec::Atrac(core::mem::transmute(param.audio_cfg.mcc.cie.atrac_info))
+                        }
                         _ => Codec::Unknown,
                     },
                 },
@@ -265,6 +421,11 @@ impl<'a> From<(esp_a2d_cb_event_t, &'a esp_a2d_cb_param_t)> for A2dpEvent<'a> {
                 esp_a2d_cb_event_t_ESP_A2D_REPORT_SNK_DELAY_VALUE_EVT => {
                     Self::SourceDelay(param.a2d_report_delay_value_stat.delay_value)
                 }
+                #[cfg(esp_idf_bt_a2dp_use_external_codec)]
+                esp_a2d_cb_event_t_ESP_A2D_SEP_REG_STATE_EVT => Self::SinkEndpointRegistered {
+                    seid: param.a2d_sep_reg_stat.seid,
+                    state: param.a2d_sep_reg_stat.reg_state.try_into().unwrap(),
+                },
                 _ => Self::Other {
                     raw_event: event,
                     raw_data: EventRawData(param),
@@ -293,6 +454,44 @@ where
 {
     pub fn new_sink(driver: T) -> Result<Self, EspError> {
         Self::new(driver)
+    }
+
+    /// Create a sink that operates in external-codec mode: Bluedroid does
+    /// no in-stack decoding, and instead delivers raw AVDTP media payloads
+    /// to the user via [`A2dpEvent::SinkAudioData`]. The caller must then
+    /// register one or more stream endpoints with
+    /// [`Self::register_sink_endpoint`] before a peer can connect.
+    ///
+    /// Requires `CONFIG_BT_A2DP_USE_EXTERNAL_CODEC=y` in `sdkconfig`.
+    #[cfg(esp_idf_bt_a2dp_use_external_codec)]
+    pub fn new_external_codec(driver: T) -> Result<Self, EspError> {
+        SINGLETON.take()?;
+
+        esp!(unsafe { esp_a2d_register_callback(Some(Self::event_handler)) })?;
+        esp!(unsafe {
+            esp_a2d_sink_register_audio_data_callback(Some(Self::sink_audio_data_handler))
+        })?;
+        esp!(unsafe { esp_a2d_sink_init() })?;
+
+        Ok(Self {
+            _driver: driver,
+            _p: PhantomData,
+            _m: PhantomData,
+            _s: PhantomData,
+        })
+    }
+
+    /// Register a Stream Endpoint advertising the given codec capability.
+    /// `seid` must be < `CONFIG_BT_A2DP_SEP_NUM_MAX` and lower SEIDs are
+    /// negotiated with higher priority. The async result is delivered
+    /// later as [`A2dpEvent::SinkEndpointRegistered`].
+    ///
+    /// SBC must be registered for A2DP-spec compliance, so a typical
+    /// AAC-preferring sink registers AAC at seid 0 and SBC at seid 1.
+    #[cfg(esp_idf_bt_a2dp_use_external_codec)]
+    pub fn register_sink_endpoint(&self, seid: u8, codec: &Codec) -> Result<(), EspError> {
+        let mcc = codec.to_raw_mcc()?;
+        esp!(unsafe { esp_a2d_sink_register_stream_endpoint(seid, &mcc) })
     }
 }
 
@@ -459,6 +658,22 @@ where
         trace!("Got event {{ {:#?} }}", event);
 
         SINGLETON.call(event) as _
+    }
+
+    #[cfg(esp_idf_bt_a2dp_use_external_codec)]
+    unsafe extern "C" fn sink_audio_data_handler(
+        _conn_hdl: esp_a2d_conn_hdl_t,
+        buf: *mut esp_a2d_audio_buff_t,
+    ) {
+        // Bluedroid never passes a null buffer here; if it ever did, the
+        // safest thing is to drop the event silently.
+        let Some(nn) = NonNull::new(buf) else {
+            return;
+        };
+        let event = A2dpEvent::SinkAudioData(A2dpAudioBuf(nn));
+        trace!("Got event {{ {:#?} }}", event);
+
+        SINGLETON.call(event);
     }
 }
 

--- a/src/bt/a2dp.rs
+++ b/src/bt/a2dp.rs
@@ -227,29 +227,11 @@ pub enum ConnectionStatus {
 pub enum AudioStatus {
     // The C enum dropped REMOTE_SUSPEND in favour of plain SUSPEND in
     // esp-idf >= 5.2; the Rust variant name is kept stable for API users.
-    #[cfg(any(
-        esp_idf_version_major = "4",
-        all(
-            esp_idf_version_major = "5",
-            any(esp_idf_version_minor = "0", esp_idf_version_minor = "1")
-        ),
-    ))]
+    #[cfg(not(esp_idf_version_at_least_5_2_0))]
     SuspendedByRemote = esp_a2d_audio_state_t_ESP_A2D_AUDIO_STATE_REMOTE_SUSPEND,
-    #[cfg(not(any(
-        esp_idf_version_major = "4",
-        all(
-            esp_idf_version_major = "5",
-            any(esp_idf_version_minor = "0", esp_idf_version_minor = "1")
-        ),
-    )))]
+    #[cfg(esp_idf_version_at_least_5_2_0)]
     SuspendedByRemote = esp_a2d_audio_state_t_ESP_A2D_AUDIO_STATE_SUSPEND,
-    #[cfg(any(
-        esp_idf_version_major = "4",
-        all(
-            esp_idf_version_major = "5",
-            any(esp_idf_version_minor = "0", esp_idf_version_minor = "1")
-        ),
-    ))]
+    #[cfg(not(esp_idf_version_at_least_5_2_0))]
     Stopped = esp_a2d_audio_state_t_ESP_A2D_AUDIO_STATE_STOPPED,
     Started = esp_a2d_audio_state_t_ESP_A2D_AUDIO_STATE_STARTED,
 }
@@ -261,13 +243,7 @@ pub enum MediaControlCommand {
     CheckSourceReady = esp_a2d_media_ctrl_t_ESP_A2D_MEDIA_CTRL_CHECK_SRC_RDY,
     Start = esp_a2d_media_ctrl_t_ESP_A2D_MEDIA_CTRL_START,
     // STOP was dropped in esp-idf >= 5.2.
-    #[cfg(any(
-        esp_idf_version_major = "4",
-        all(
-            esp_idf_version_major = "5",
-            any(esp_idf_version_minor = "0", esp_idf_version_minor = "1")
-        ),
-    ))]
+    #[cfg(not(esp_idf_version_at_least_5_2_0))]
     Stop = esp_a2d_media_ctrl_t_ESP_A2D_MEDIA_CTRL_STOP,
     Suspend = esp_a2d_media_ctrl_t_ESP_A2D_MEDIA_CTRL_SUSPEND,
 }

--- a/src/bt/a2dp.rs
+++ b/src/bt/a2dp.rs
@@ -96,19 +96,33 @@ impl Codec {
                 // AAC sample-frequency bitmap (AVDTP A2DP 4.5.2):
                 // byte 1 covers 8 kHz..44.1 kHz, byte 2 high nibble covers 48..96 kHz.
                 // After negotiation exactly one bit is set.
-                if data[2] & 0x80 != 0 { Some(48000) }
-                else if data[1] & 0x01 != 0 { Some(44100) }
-                else if data[1] & 0x02 != 0 { Some(32000) }
-                else if data[1] & 0x04 != 0 { Some(24000) }
-                else if data[1] & 0x08 != 0 { Some(22050) }
-                else if data[1] & 0x10 != 0 { Some(16000) }
-                else if data[1] & 0x20 != 0 { Some(12000) }
-                else if data[1] & 0x40 != 0 { Some(11025) }
-                else if data[1] & 0x80 != 0 { Some(8000) }
-                else if data[2] & 0x40 != 0 { Some(64000) }
-                else if data[2] & 0x20 != 0 { Some(88200) }
-                else if data[2] & 0x10 != 0 { Some(96000) }
-                else { None }
+                if data[2] & 0x80 != 0 {
+                    Some(48000)
+                } else if data[1] & 0x01 != 0 {
+                    Some(44100)
+                } else if data[1] & 0x02 != 0 {
+                    Some(32000)
+                } else if data[1] & 0x04 != 0 {
+                    Some(24000)
+                } else if data[1] & 0x08 != 0 {
+                    Some(22050)
+                } else if data[1] & 0x10 != 0 {
+                    Some(16000)
+                } else if data[1] & 0x20 != 0 {
+                    Some(12000)
+                } else if data[1] & 0x40 != 0 {
+                    Some(11025)
+                } else if data[1] & 0x80 != 0 {
+                    Some(8000)
+                } else if data[2] & 0x40 != 0 {
+                    Some(64000)
+                } else if data[2] & 0x20 != 0 {
+                    Some(88200)
+                } else if data[2] & 0x10 != 0 {
+                    Some(96000)
+                } else {
+                    None
+                }
             }
             _ => None,
         }
@@ -378,7 +392,10 @@ pub enum A2dpEvent<'a> {
     SinkAudioData(A2dpAudioBuf),
     /// Result of a prior `register_sink_endpoint` call.
     #[cfg(esp_idf_bt_a2dp_use_external_codec)]
-    SinkEndpointRegistered { seid: u8, state: SepRegState },
+    SinkEndpointRegistered {
+        seid: u8,
+        state: SepRegState,
+    },
     Other {
         raw_event: esp_a2d_cb_event_t,
         raw_data: EventRawData<'a>,

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -2350,8 +2350,13 @@ impl fmt::Debug for DppUriReadyRef {
 }
 
 /// Payload reference for [`WifiEvent::DppCfgRecvd`].
+///
+/// Not `Copy`/`Clone`: recent ESP-IDF added a flexible-array-member
+/// field (`configs[]`) to `wifi_event_dpp_config_received_t`, which
+/// bindgen surfaces as `__IncompleteArrayField` (intentionally not
+/// `Clone`). The newtype is always borrowed via `&'a DppCfgRecvdRef`
+/// inside event callbacks, so the derive was never load-bearing.
 #[cfg(esp_idf_version_at_least_5_5_0)]
-#[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct DppCfgRecvdRef(wifi_event_dpp_config_received_t);
 
@@ -2669,7 +2674,14 @@ impl EspEventDeserializer for WifiEvent<'_> {
             }
             #[cfg(esp_idf_version_at_least_5_5_0)]
             wifi_event_t_WIFI_EVENT_DPP_CFG_RECVD => {
-                WifiEvent::DppCfgRecvd(unsafe { data.as_payload() })
+                // `wifi_event_dpp_config_received_t` contains
+                // `__IncompleteArrayField` which prevents deriving `Copy`,
+                // so we cannot use `as_payload()`.
+                WifiEvent::DppCfgRecvd(unsafe {
+                    (data.payload.unwrap() as *const _ as *const DppCfgRecvdRef)
+                        .as_ref()
+                        .unwrap()
+                })
             }
             #[cfg(esp_idf_version_at_least_5_5_0)]
             wifi_event_t_WIFI_EVENT_DPP_FAILED => {


### PR DESCRIPTION


### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
The latest build of esp-idf supports a new bt classic a2dp sink mode for external codec integration.  It has a new api surface, that plumbs the encoded audio to the application for decoding using your own codecs (or esp_audio_codec).   I have added support for this api, and I have added an example that shows pairing a2dp with an iphone using AAC codec params, and a callback triggers with the encoded aac data.  

I do have this working with https://github.com/billylindeman/esp-audio-codec-rs decoding AAC from my iphone on a project I'm working on 


#### Testing
To run the example: 
```bash 
MCU=esp32 ESP_IDF_VERSION=master ESP_IDF_SDKCONFIG_DEFAULTS=.github/configs/sdkconfig.a2dp_external_codec cargo +esp espflash flash --target xtensa-esp32-espidf --example bt_a2dp_sink_external_codec --monitor
```

```Chip type:         esp32 (revision v3.1)
Crystal frequency: 40 MHz
Flash size:        8MB
Features:          WiFi, BT, Dual Core, 240MHz, VRef calibration in efuse, Coding Scheme None

I (1421) main_task: Started on CPU0
I (1421) esp_psram: Reserving pool of 32K of internal memory for DMA/internal allocations
I (1431) main_task: Calling app_main()
I (1431) bt_a2dp_sink_external_codec::example: step 1: logger up
I (1441) bt_a2dp_sink_external_codec::example: step 2: peripherals taken
I (1461) bt_a2dp_sink_external_codec::example: step 3: nvs taken
I (1471) bt_a2dp_sink_external_codec::example: step 4: reduce_bt_memory ok
I (1471) esp_idf_svc::bt: Init bluetooth controller
I (1471) BTDM_INIT: BT controller compile version [003f89d]
I (1481) BTDM_INIT: Using main XTAL as clock source
I (1491) esp_idf_svc::bt: Enable bluetooth controller
I (2021) esp_idf_svc::bt: Init bluedroid
I (2031) esp_idf_svc::bt: Enable bluedroid
I (2101) bt_a2dp_sink_external_codec::example: step 5: BtDriver up
I (2101) bt_a2dp_sink_external_codec::example: step 6: gap created
I (2111) bt_a2dp_sink_external_codec::example: step 7: gap configured
W (2121) BT_BTC: A2DP Enable without AVRC
I (2131) esp_idf_svc::bt::a2dp: Got event { Initialized }
I (2131) bt_a2dp_sink_external_codec::example: step 8: a2dp external-codec sink up
I (2131) bt_a2dp_sink_external_codec::example: step 9: subscribed; registering SEPs
I (2141) bt_a2dp_sink_external_codec::example: registering AAC at seid 0
I (2151) esp_idf_svc::bt::a2dp: Got event { SinkEndpointRegistered {
    seid: 0,
    state: Success,
} }
I (2151) bt_a2dp_sink_external_codec::example: SEP 0 register result: Success
I (2161) bt_a2dp_sink_external_codec::example: registering SBC at seid 1
I (2171) esp_idf_svc::bt::a2dp: Got event { SinkEndpointRegistered {
    seid: 1,
    state: Success,
} }
I (2181) bt_a2dp_sink_external_codec::example: SEP 1 register result: Success
I (2181) bt_a2dp_sink_external_codec::example: step 10: A2DP sink ready; pair with phone and play audio
W (13191) BT_HCI: hcif conn complete: hdl 0x80, st 0x0
W (13291) BT_HCI: hcif link supv_to changed: hdl 0x80, supv_to 8000
W (13471) BT_HCI: hcif link supv_to changed: hdl 0x80, supv_to 32000
W (13731) BT_HCI: hcif link supv_to changed: hdl 0x80, supv_to 8000
I (13751) esp_idf_svc::bt::a2dp: Got event { ConnectionState {
    status: Connecting,
    disconnect_abnormal: false,
} }
W (13751) BT_L2CAP: L2CAP - rcvd conn req for unknown PSM: 23
I (13771) bt_a2dp_sink_external_codec::example: a2dp event: ConnectionState { bd_addr: Status: Connecting, disconnect_abnormal: false }
W (14061) BT_RFCOMM: rfc_find_lcid_mcb LCID reused LCID:0x41 current:0x0
W (14061) BT_RFCOMM: RFCOMM_DisconnectInd LCID:0x41
I (14071) esp_idf_svc::bt::a2dp: Got event { AudioCodecConfigured {
    ),
    codec: Mpeg2_4(
        [
            128,
            1,
            4,
            131,
            232,
            0,
        ],
    ) / bitrate: Some(44100), stereo: Some(true),
} }
I (14101) bt_a2dp_sink_external_codec::example: negotiated codec with: Mpeg2_4([128, 1, 4, 131, 232, 0]) / bitrate: Some(44100), stereo: Some(true)
I (14121) esp_idf_svc::bt::a2dp: Got event { SinkServiceCapabilitiesConfigured(
    1,
) }
I (14131) bt_a2dp_sink_external_codec::example: a2dp event: SinkServiceCapabilitiesConfigured(1)
W (14431) BT_APPL: new conn_srvc id:19, app_id:0
I (14431) esp_idf_svc::bt::a2dp: Got event { ConnectionState {
    bd_addr: 
    status: Connected,
    disconnect_abnormal: false,
} }
I (14451) bt_a2dp_sink_external_codec::example: a2dp event: ConnectionState { bd_addr:), status: Connected, disconnect_abnormal: false }
W (14461) BT_BTC: AVRC not Init, not using it.
W (17631) BT_HCI: hci cmd send: sniff: hdl 0x80, intv(400 800)
W (17691) BT_HCI: hcif mode change: hdl 0x80, mode 2, intv 800, status 0x0
W (17931) BT_HCI: hcif mode change: hdl 0x80, mode 0, intv 0, status 0x0
I (17951) BT_LOG: bta_av_link_role_ok hndl:x41 role:1 conn_audio:x1 bits:1 features:x8400

W (17951) BT_APPL: new conn_srvc id:19, app_id:1
I (17961) esp_idf_svc::bt::a2dp: Got event { AudioState {
    bd_addr:
    ),
    status: Started,
} }
I (17971) bt_a2dp_sink_external_codec::example: a2dp event: AudioState { bd_addr), status: Started }
I (18011) bt_a2dp_sink_external_codec::example: audio frame: 1 frames, 32 bytes, ts 43004047
I (18041) bt_a2dp_sink_external_codec::example: audio frame: 1 frames, 32 bytes, ts 43004069
I (18061) bt_a2dp_sink_external_codec::example: audio frame: 1 frames, 714 bytes, ts 43004093
I (18081) bt_a2dp_sink_external_codec::example: audio frame: 1 frames, 676 bytes, ts 43004116
```