### PR TITLE
bt a2dp: handle null buffer in SourceData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- BT: Fixed panic when an A2DP sink disconnects from the ESP while streaming audio.
+
 ## [0.52.1] - 2026-03-10
 
 ### Fixed

--- a/src/bt/a2dp.rs
+++ b/src/bt/a2dp.rs
@@ -455,6 +455,9 @@ where
     }
 
     unsafe extern "C" fn source_data_handler(buf: *mut u8, len: i32) -> i32 {
+        if buf.is_null() || len <= 0 {
+            return 0; // nothing to read; matches the "bytes provided" contract
+        }
         let event = A2dpEvent::SourceData(core::slice::from_raw_parts_mut(buf, len as _));
         trace!("Got event {{ {:#?} }}", event);
 


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
This happens then the A2DP Sink disconnects (in my case, turning off the bluetooth speaker while connected to the ESP).

#### Testing
Tested on my classic ESP32 DevKit, works fine.