### PR TITLE
Thread callback fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ remote_component = { name = "espressif/lan87xx", version = "1.*" }
 - WiFi: receiving any of the six new events listed above on ESP-IDF v5.3+ / v5.5+ no longer causes a panic (fixes #618)
 - WebSocket: `EspWebSocketClient::drop()` no longer panics when `esp_websocket_client_close` returns `ESP_FAIL` (e.g. after a network disconnection); errors are now logged instead of unwrapped
 - BT: Fixed panic when an A2DP sink disconnects from the ESP while streaming audio.
+- Thread: `scan`, `energy_scan` and the IPv6 receive callbacks no longer pass the wrong context pointer to OpenThread (the closure box instead of the `ThreadDriverInner`), fixing a type-confusion crash when the callbacks fire.
 
 ### Added
 - Compatibility with ESP-IDF V6.0, and some pre-release 6.0.x.

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -488,22 +488,28 @@ impl<'d> ThreadDriver<'d, Host> {
         }
 
         #[allow(clippy::type_complexity)]
-        let mut callback: Box<Box<dyn FnMut(Option<ActiveScanResult>) + Send + 'static>> =
+        let callback: Box<Box<dyn FnMut(Option<ActiveScanResult>) + Send + 'static>> =
             Box::new(Box::new(callback));
 
-        ot_esp!(unsafe {
+        // Store callback where on_active_scan_result can get to it
+        inner.scan_cb = Some(callback);
+
+        match ot_esp!(unsafe {
             otLinkActiveScan(
                 esp_openthread_get_instance(),
                 0xffff_ffffu32, // All channels
                 200,            // ms scan per channel
                 Some(Self::on_active_scan_result),
-                callback.as_mut() as *mut _ as *mut c_void,
+                &mut *inner as *mut ThreadDriverInner as *mut c_void,
             )
-        })?;
-
-        inner.scan_cb = Some(callback);
-
-        Ok(())
+        }) {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                // Clean up inner if we fail to start the scan
+                inner.scan_cb = None;
+                Err(err)
+            }
+        }
     }
 
     /// Check if an active scan is in progress
@@ -528,22 +534,28 @@ impl<'d> ThreadDriver<'d, Host> {
         }
 
         #[allow(clippy::type_complexity)]
-        let mut callback: Box<Box<dyn FnMut(Option<EnergyScanResult>) + Send + 'static>> =
+        let callback: Box<Box<dyn FnMut(Option<EnergyScanResult>) + Send + 'static>> =
             Box::new(Box::new(callback));
 
-        ot_esp!(unsafe {
+        // Store callback where on_energy_scan_result can get to it
+        inner.energy_cb = Some(callback);
+
+        match ot_esp!(unsafe {
             otLinkEnergyScan(
                 esp_openthread_get_instance(),
                 0xffff_ffffu32, // All channels
                 200,            // ms scan per channel
                 Some(Self::on_energy_scan_result),
-                callback.as_mut() as *mut _ as *mut c_void,
+                &mut *inner as *mut ThreadDriverInner as *mut c_void,
             )
-        })?;
-
-        inner.energy_cb = Some(callback);
-
-        Ok(())
+        }) {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                // Clean up inner if we fail to start the scan
+                inner.energy_cb = None;
+                Err(err)
+            }
+        }
     }
 
     /// Check if an energy scan is in progress
@@ -632,23 +644,22 @@ impl<'d> ThreadDriver<'d, Host> {
                 Box::new(Box::new(callback));
 
             #[allow(clippy::type_complexity)]
-            let mut callback: Box<Box<dyn FnMut(Ipv6Incoming) + Send + 'static>> =
+            let callback: Box<Box<dyn FnMut(Ipv6Incoming) + Send + 'static>> =
                 unsafe { core::mem::transmute(callback) };
 
-            let callback_ptr = callback.as_mut() as *mut _ as *mut c_void;
-
+            // Stick the callback where Self::on_address/Self::on_packet can get to it
             inner.ipv6_cb = Some(callback);
 
             unsafe {
                 otIp6SetAddressCallback(
                     esp_openthread_get_instance(),
                     Some(Self::on_address),
-                    callback_ptr,
+                    &mut *inner as *mut ThreadDriverInner as *mut c_void,
                 );
                 otIp6SetReceiveCallback(
                     esp_openthread_get_instance(),
                     Some(Self::on_packet),
-                    callback_ptr,
+                    &mut *inner as *mut ThreadDriverInner as *mut c_void,
                 );
                 otIp6SetReceiveFilterEnabled(esp_openthread_get_instance(), true);
 


### PR DESCRIPTION

### Submission Checklist 📝
- [NA] I have updated existing examples or added new ones (if applicable).
- [X] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [X] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [X] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description

Trampolines here expect a pointer to ThreadDriverInner but we were giving them pointers to callbacks, causing crashes. This sets the callbacks on ThreadDriverInner and passes that pointer instead


#### Testing

When provisioning my device with Home Assistant and it's iOS app, it enables this "active scan" thing during provisioning that no other hub I've tried does, and that in turn crashes for me without this patch. 

The ipv6 callbacks have the same problem, with this patch I'm able to set callbacks to debug low-level traffic. 