### PR TITLE
Gate Ethernet module on managed SPI PHY components for IDF 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ remote_component = { name = "espressif/lan87xx", version = "1.*" }
 - WebSocket: `EspWebSocketClient::drop()` no longer panics when `esp_websocket_client_close` returns `ESP_FAIL` (e.g. after a network disconnection); errors are now logged instead of unwrapped
 - BT: Fixed panic when an A2DP sink disconnects from the ESP while streaming audio.
 - Thread: `scan`, `energy_scan` and the IPv6 receive callbacks no longer pass the wrong context pointer to OpenThread (the closure box instead of the `ThreadDriverInner`), fixing a type-confusion crash when the callbacks fire.
+- Ethernet: `mod eth` is enabled again on ESP-IDF 6.0+ when SPI Ethernet PHYs are provided as managed components (`espressif/w5500`, `espressif/dm9051`, `espressif/ksz8851snl`), not only via the removed in-tree `CONFIG_ETH_SPI_ETHERNET_*` Kconfig options
 
 ### Added
 - Compatibility with ESP-IDF V6.0, and some pre-release 6.0.x.

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -14,7 +14,11 @@ use embedded_svc::eth::*;
     any(
         esp_idf_eth_spi_ethernet_dm9051,
         esp_idf_eth_spi_ethernet_w5500,
-        esp_idf_eth_spi_ethernet_ksz8851snl
+        esp_idf_eth_spi_ethernet_ksz8851snl,
+        // ESP-IDF 6.0+ managed components
+        esp_idf_comp_espressif__dm9051_enabled,
+        esp_idf_comp_espressif__w5500_enabled,
+        esp_idf_comp_espressif__ksz8851snl_enabled,
     )
 ))]
 use crate::hal::gpio;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,13 +48,18 @@ pub mod espnow;
     esp_idf_comp_esp_event_enabled,
 ))]
 #[cfg(any(
+    // On-chip EMAC (ESP32); RMII PHYs such as lan87xx are used only with EMAC
     all(esp32, esp_idf_eth_use_esp32_emac),
     any(
         esp_idf_eth_spi_ethernet_dm9051,
         esp_idf_eth_spi_ethernet_w5500,
-        esp_idf_eth_spi_ethernet_ksz8851snl
+        esp_idf_eth_spi_ethernet_ksz8851snl,
+        // ESP-IDF 6.0+ ships SPI Ethernet PHYs as managed components
+        esp_idf_comp_espressif__dm9051_enabled,
+        esp_idf_comp_espressif__w5500_enabled,
+        esp_idf_comp_espressif__ksz8851snl_enabled,
     ),
-    esp_idf_eth_use_openeth
+    esp_idf_eth_use_openeth,
 ))]
 pub mod eth;
 #[cfg(all(feature = "alloc", esp_idf_comp_esp_event_enabled))]


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [ ] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/master/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
On ESP-IDF 6.0+, in-tree `CONFIG_ETH_SPI_ETHERNET_*` Kconfig options are gone; SPI Ethernet PHYs ship as managed components (`espressif/w5500`, `espressif/dm9051`, `espressif/ksz8851snl`).

This change gates `mod eth` (and the related GPIO import in `eth.rs`) on the corresponding `esp_idf_comp_espressif__*_enabled` cfg flags in addition to the legacy in-tree flags, so the Ethernet module continues to build when those components are present.