### PR TITLE
BT: Advertising does not work with ESP-IDF 5.5+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ remote_component = { name = "espressif/lan87xx", version = "1.*" }
 ```
 
 ### Fixed
+- BT/BLE: Advertising was not working with ESP-IDF 5.5+ and esp32, esp32c3 and esp32s3
+- BT/BLE: Extended advertising exvets were mis-mapped as `BleGapEvent::Other`
 - WiFi: receiving any of the six new events listed above on ESP-IDF v5.3+ / v5.5+ no longer causes a panic (fixes #618)
 - WebSocket: `EspWebSocketClient::drop()` no longer panics when `esp_websocket_client_close` returns `ESP_FAIL` (e.g. after a network disconnection); errors are now logged instead of unwrapped
 - MQTT: MQTT 5.0 CONNECT properties can now be set on `EspMqttClient` without deadlocking on `MQTT_API_LOCK`; they are applied inside the library between `esp_mqtt_client_init` and `esp_mqtt_client_start` via the new [`MqttClientConfiguration::mqtt5_connection_property`] field.

--- a/src/bt.rs
+++ b/src/bt.rs
@@ -563,19 +563,41 @@ where
             scan_en: crate::sys::BT_CTRL_BLE_SCAN != 0,
             ble_aa_check: crate::sys::BLE_CTRL_CHECK_CONNECT_IND_ACCESS_ADDRESS_ENABLED != 0,
             #[cfg(any(
-                esp_idf_version_patch_at_least_5_1_7,
-                esp_idf_version_patch_at_least_5_2_6,
-                esp_idf_version_patch_at_least_5_3_3,
-                esp_idf_version_patch_at_least_5_4_2,
-                esp_idf_version_at_least_5_5_0,
+                all(
+                    esp_idf_version_patch_at_least_5_2_6,
+                    esp_idf_version_patch_at_most_5_2_6
+                ),
+                all(
+                    esp_idf_version_patch_at_least_5_3_3,
+                    esp_idf_version_patch_at_most_5_3_4
+                ),
+                all(
+                    esp_idf_version_patch_at_least_5_4_2,
+                    esp_idf_version_patch_at_most_5_4_3
+                ),
+                all(
+                    esp_idf_version_patch_at_least_5_5_0,
+                    esp_idf_version_patch_at_most_5_5_1
+                ),
             ))]
             ble_log_mode_en: crate::sys::BLE_LOG_MODE_EN,
             #[cfg(any(
-                esp_idf_version_patch_at_least_5_1_7,
-                esp_idf_version_patch_at_least_5_2_6,
-                esp_idf_version_patch_at_least_5_3_3,
-                esp_idf_version_patch_at_least_5_4_2,
-                esp_idf_version_at_least_5_5_0,
+                all(
+                    esp_idf_version_patch_at_least_5_2_6,
+                    esp_idf_version_patch_at_most_5_2_6
+                ),
+                all(
+                    esp_idf_version_patch_at_least_5_3_3,
+                    esp_idf_version_patch_at_most_5_3_4
+                ),
+                all(
+                    esp_idf_version_patch_at_least_5_4_2,
+                    esp_idf_version_patch_at_most_5_4_3
+                ),
+                all(
+                    esp_idf_version_patch_at_least_5_5_0,
+                    esp_idf_version_patch_at_most_5_5_1
+                ),
             ))]
             ble_log_level: crate::sys::BLE_LOG_LEVEL as _,
             #[cfg(any(

--- a/src/bt.rs
+++ b/src/bt.rs
@@ -495,7 +495,7 @@ where
                 esp_idf_version_patch_at_least_5_2_6,
                 esp_idf_version_patch_at_least_5_3_3,
                 esp_idf_version_patch_at_least_5_4_1,
-                esp_idf_version_least_5_5_0,
+                esp_idf_version_at_least_5_5_0,
             ))]
             enc_key_sz_min: crate::sys::CONFIG_BTDM_CTRL_BR_EDR_MIN_ENC_KEY_SZ_DFT_EFF as _,
             dup_list_refresh_period: crate::sys::SCAN_DUPL_CACHE_REFRESH_PERIOD as _,
@@ -557,7 +557,7 @@ where
                 esp_idf_version_patch_at_least_5_2_6,
                 esp_idf_version_patch_at_least_5_3_4,
                 esp_idf_version_patch_at_least_5_4_2,
-                esp_idf_version_least_5_5_0,
+                esp_idf_version_at_least_5_5_0,
             ))]
             connect_en: crate::sys::BT_CTRL_BLE_MASTER != 0,
             scan_en: crate::sys::BT_CTRL_BLE_SCAN != 0,
@@ -567,7 +567,7 @@ where
                 esp_idf_version_patch_at_least_5_2_6,
                 esp_idf_version_patch_at_least_5_3_3,
                 esp_idf_version_patch_at_least_5_4_2,
-                esp_idf_version_least_5_5_0,
+                esp_idf_version_at_least_5_5_0,
             ))]
             ble_log_mode_en: crate::sys::BLE_LOG_MODE_EN,
             #[cfg(any(
@@ -575,7 +575,7 @@ where
                 esp_idf_version_patch_at_least_5_2_6,
                 esp_idf_version_patch_at_least_5_3_3,
                 esp_idf_version_patch_at_least_5_4_2,
-                esp_idf_version_least_5_5_0,
+                esp_idf_version_at_least_5_5_0,
             ))]
             ble_log_level: crate::sys::BLE_LOG_LEVEL as _,
             #[cfg(any(
@@ -583,7 +583,7 @@ where
                 esp_idf_version_patch_at_least_5_2_6,
                 esp_idf_version_patch_at_least_5_3_4,
                 esp_idf_version_patch_at_least_5_4_2,
-                esp_idf_version_least_5_5_0,
+                esp_idf_version_at_least_5_5_0,
             ))]
             adv_en: crate::sys::BT_CTRL_BLE_ADV != 0,
             ..Default::default()

--- a/src/bt/ble/gap.rs
+++ b/src/bt/ble/gap.rs
@@ -321,7 +321,7 @@ pub enum ScanDuplicate {
     #[default]
     Disable = esp_ble_scan_duplicate_t_BLE_SCAN_DUPLICATE_DISABLE,
     Enable = esp_ble_scan_duplicate_t_BLE_SCAN_DUPLICATE_ENABLE,
-    #[cfg(esp_idf_ble_50_feature_support)]
+    #[cfg(esp_idf_bt_ble_50_features_supported)]
     Reset = esp_ble_scan_duplicate_t_BLE_SCAN_DUPLICATE_ENABLE_RESET,
     Max = esp_ble_scan_duplicate_t_BLE_SCAN_DUPLICATE_MAX,
 }
@@ -726,6 +726,164 @@ impl<'a> From<(esp_gap_ble_cb_event_t, &'a esp_ble_gap_cb_param_t)> for BleGapEv
                 }
                 esp_gap_ble_cb_event_t_ESP_GAP_BLE_SET_CHANNELS_EVT => {
                     Self::ChannelsConfigured(param.ble_set_channels.stat.try_into().unwrap())
+                }
+                // BLE 5.0 - PHY
+                #[cfg(esp_idf_bt_ble_50_features_supported)]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_READ_PHY_COMPLETE_EVT => {
+                    Self::ReadFeaturesConfigured(param.read_phy)
+                }
+                // The `SET_PREFERED_*` events were renamed to `SET_PREFERRED_*` after ESP-IDF 4.4
+                #[cfg(all(esp_idf_bt_ble_50_features_supported, esp_idf_version_major = "4"))]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_SET_PREFERED_DEFAULT_PHY_COMPLETE_EVT => {
+                    Self::PreferredDefaultPhyConfigured(
+                        param.set_perf_def_phy.status.try_into().unwrap(),
+                    )
+                }
+                #[cfg(all(esp_idf_bt_ble_50_features_supported, not(esp_idf_version_major = "4")))]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_SET_PREFERRED_DEFAULT_PHY_COMPLETE_EVT => {
+                    Self::PreferredDefaultPhyConfigured(
+                        param.set_perf_def_phy.status.try_into().unwrap(),
+                    )
+                }
+                #[cfg(all(esp_idf_bt_ble_50_features_supported, esp_idf_version_major = "4"))]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_SET_PREFERED_PHY_COMPLETE_EVT => {
+                    Self::PreferredPhyConfigured(param.set_perf_phy.status.try_into().unwrap())
+                }
+                #[cfg(all(esp_idf_bt_ble_50_features_supported, not(esp_idf_version_major = "4")))]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_SET_PREFERRED_PHY_COMPLETE_EVT => {
+                    Self::PreferredPhyConfigured(param.set_perf_phy.status.try_into().unwrap())
+                }
+                // BLE 5.0 - Extended advertising (needs the extended-advertising sub-feature, as the
+                // corresponding fields of the callback param union are only present in that case)
+                #[cfg(all(esp_idf_bt_ble_50_features_supported, esp_idf_bt_ble_50_extend_adv_en))]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_EXT_ADV_SET_RAND_ADDR_COMPLETE_EVT => {
+                    Self::ExtendedAdvertisingRandomAddressConfigured(
+                        param.ext_adv_set_rand_addr.status.try_into().unwrap(),
+                    )
+                }
+                #[cfg(all(esp_idf_bt_ble_50_features_supported, esp_idf_bt_ble_50_extend_adv_en))]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_EXT_ADV_SET_PARAMS_COMPLETE_EVT => {
+                    Self::ExtendedAdvertisingParametersConfigured(
+                        param.ext_adv_set_params.status.try_into().unwrap(),
+                    )
+                }
+                #[cfg(all(esp_idf_bt_ble_50_features_supported, esp_idf_bt_ble_50_extend_adv_en))]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_EXT_ADV_DATA_SET_COMPLETE_EVT => {
+                    Self::ExtendedAdvertisingConfigured(
+                        param.ext_adv_data_set.status.try_into().unwrap(),
+                    )
+                }
+                #[cfg(all(esp_idf_bt_ble_50_features_supported, esp_idf_bt_ble_50_extend_adv_en))]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_EXT_SCAN_RSP_DATA_SET_COMPLETE_EVT => {
+                    Self::ExtendedAdvertisingScanResponseConfigured(
+                        param.scan_rsp_set.status.try_into().unwrap(),
+                    )
+                }
+                #[cfg(all(esp_idf_bt_ble_50_features_supported, esp_idf_bt_ble_50_extend_adv_en))]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_EXT_ADV_START_COMPLETE_EVT => {
+                    Self::ExtendedAdvertisingStarted(param.ext_adv_start.status.try_into().unwrap())
+                }
+                #[cfg(all(esp_idf_bt_ble_50_features_supported, esp_idf_bt_ble_50_extend_adv_en))]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_EXT_ADV_STOP_COMPLETE_EVT => {
+                    Self::ExtendedAdvertisingStopped(param.ext_adv_stop.status.try_into().unwrap())
+                }
+                #[cfg(all(esp_idf_bt_ble_50_features_supported, esp_idf_bt_ble_50_extend_adv_en))]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_EXT_ADV_SET_REMOVE_COMPLETE_EVT => {
+                    Self::ExtendedAdvertisingRemoved(
+                        param.ext_adv_remove.status.try_into().unwrap(),
+                    )
+                }
+                #[cfg(all(esp_idf_bt_ble_50_features_supported, esp_idf_bt_ble_50_extend_adv_en))]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_EXT_ADV_SET_CLEAR_COMPLETE_EVT => {
+                    Self::ExtendedAdvertisingCleared(param.ext_adv_clear.status.try_into().unwrap())
+                }
+                // BLE 5.0 - Periodic advertising
+                #[cfg(esp_idf_bt_ble_50_features_supported)]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_PERIODIC_ADV_SET_PARAMS_COMPLETE_EVT => {
+                    // Note: the field name is misspelled as `peroid_adv_set_params` in ESP-IDF
+                    Self::PeriodicAdvertisingParametersConfigured(
+                        param.peroid_adv_set_params.status.try_into().unwrap(),
+                    )
+                }
+                #[cfg(esp_idf_bt_ble_50_features_supported)]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_PERIODIC_ADV_DATA_SET_COMPLETE_EVT => {
+                    Self::PeriodicAdvertisingDataSetComplete(
+                        param.period_adv_data_set.status.try_into().unwrap(),
+                    )
+                }
+                #[cfg(esp_idf_bt_ble_50_features_supported)]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_PERIODIC_ADV_START_COMPLETE_EVT => {
+                    Self::PeriodicAdvertisingStarted(
+                        param.period_adv_start.status.try_into().unwrap(),
+                    )
+                }
+                #[cfg(esp_idf_bt_ble_50_features_supported)]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_PERIODIC_ADV_STOP_COMPLETE_EVT => {
+                    Self::PeriodicAdvertisingStopped(
+                        param.period_adv_stop.status.try_into().unwrap(),
+                    )
+                }
+                #[cfg(esp_idf_bt_ble_50_features_supported)]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_PERIODIC_ADV_CREATE_SYNC_COMPLETE_EVT => {
+                    Self::PeriodicAdvertisingSyncCreated(
+                        param.period_adv_create_sync.status.try_into().unwrap(),
+                    )
+                }
+                #[cfg(esp_idf_bt_ble_50_features_supported)]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_PERIODIC_ADV_SYNC_CANCEL_COMPLETE_EVT => {
+                    Self::PeriodicAdvertisingSyncCanceled(
+                        param.period_adv_sync_cancel.status.try_into().unwrap(),
+                    )
+                }
+                #[cfg(esp_idf_bt_ble_50_features_supported)]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_PERIODIC_ADV_SYNC_TERMINATE_COMPLETE_EVT => {
+                    Self::PeriodicAdvertisingSyncTerminated(
+                        param.period_adv_sync_term.status.try_into().unwrap(),
+                    )
+                }
+                #[cfg(esp_idf_bt_ble_50_features_supported)]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_PERIODIC_ADV_ADD_DEV_COMPLETE_EVT => {
+                    Self::PeriodicAdvertisingDeviceListAdded(
+                        param.period_adv_add_dev.status.try_into().unwrap(),
+                    )
+                }
+                #[cfg(esp_idf_bt_ble_50_features_supported)]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_PERIODIC_ADV_REMOVE_DEV_COMPLETE_EVT => {
+                    Self::PeriodicAdvertisingDeviceListRemoved(
+                        param.period_adv_remove_dev.status.try_into().unwrap(),
+                    )
+                }
+                #[cfg(esp_idf_bt_ble_50_features_supported)]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_PERIODIC_ADV_CLEAR_DEV_COMPLETE_EVT => {
+                    Self::PeriodicAdvertisingDeviceListCleared(
+                        param.period_adv_clear_dev.status.try_into().unwrap(),
+                    )
+                }
+                // BLE 5.0 - Extended scanning
+                #[cfg(esp_idf_bt_ble_50_features_supported)]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_SET_EXT_SCAN_PARAMS_COMPLETE_EVT => {
+                    Self::ExtendedAdvertisingScanParametersConfigured(
+                        param.set_ext_scan_params.status.try_into().unwrap(),
+                    )
+                }
+                #[cfg(esp_idf_bt_ble_50_features_supported)]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_EXT_SCAN_START_COMPLETE_EVT => {
+                    Self::ExtendedAdvertisingScanStarted(
+                        param.ext_scan_start.status.try_into().unwrap(),
+                    )
+                }
+                #[cfg(esp_idf_bt_ble_50_features_supported)]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_EXT_SCAN_STOP_COMPLETE_EVT => {
+                    Self::ExtendedAdvertisingScanStopped(
+                        param.ext_scan_stop.status.try_into().unwrap(),
+                    )
+                }
+                // BLE 5.0 - Extended connection
+                #[cfg(esp_idf_bt_ble_50_features_supported)]
+                esp_gap_ble_cb_event_t_ESP_GAP_BLE_PREFER_EXT_CONN_PARAMS_SET_COMPLETE_EVT => {
+                    Self::ExtendedAdvertisingExtendedConnectionParamsConfigured(
+                        param.ext_conn_params_set.status.try_into().unwrap(),
+                    )
                 }
                 _ => Self::Other {
                     raw_event: event,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description

This PR is addressing:
- Issue #663 
- This issue in esp-idf-matter: https://github.com/sysgrok/esp-idf-matter/issues/30

Both of these are caused by a wrong spelling of an ESP-IDF cfg version guard: "_least" instead of "_at_least".

Chips affected: esp32c3, esp32s3, likely the classic esp32 as well.

Additionally, following extra fixes:
- `ExtendedAdvertising*` events are no longer mis-mapped as `Other`
- `ScanDuplicate::Reset` in the `gap` module was gated on `esp_idf_ble_50_feature_support` instead of `esp_idf_bt_ble_50_features_supported`.

#### Testing

Tested with `esp-idf-matter`