### PR TITLE
Start of NimBLE wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ remote_component = { name = "espressif/lan87xx", version = "1.*" }
 ### Added
 - Compatibility with ESP-IDF V6.0, and some pre-release 6.0.x.
 - Added support for the Generic Ethernet PHY driver: particularly useful on ESP-IDF 6.0+ as it is built-in.
+- Added early support for the NimBLE low-resource-use BLE stack, currently only GAP and GATT Server support. See examples/ble_gatt_server.rs
 
 ## [0.52.1] - 2026-03-10
 

--- a/examples/ble_gatt_server.rs
+++ b/examples/ble_gatt_server.rs
@@ -94,7 +94,10 @@ mod example {
         // on the host task. We stash the indicate handle so the loop below can push to
         // it; matching on the UUID is how we tell our characteristics apart.
         setup.on_gatts_register(|event| {
-            if let BleGattRegister::Characteristic { uuid, val_handle, .. } = event {
+            if let BleGattRegister::Characteristic {
+                uuid, val_handle, ..
+            } = event
+            {
                 if uuid == BleUuid::uuid128(IND_CHARACTERISTIC_UUID) {
                     IND_VAL_HANDLE.store(val_handle, Ordering::Relaxed);
                 }
@@ -170,7 +173,7 @@ mod example {
         }
     }
 
-    /// Configure and start a connectable legacy advertisement 
+    /// Configure and start a connectable legacy advertisement
     /// n.b. NimBLE exposes a mutually-exclusive "extended" advertisement API as well
     /// if you set the right build flags
     fn start_advertising() -> Result<(), BleError> {
@@ -187,8 +190,8 @@ mod example {
         gap::adv_set_fields(&fields)?;
 
         let params = BleAdvParams {
-            conn_mode: 2, // BLE_GAP_CONN_MODE_UND
-            disc_mode: 2, // BLE_GAP_DISC_MODE_GEN
+            conn_mode: 2,   // BLE_GAP_CONN_MODE_UND
+            disc_mode: 2,   // BLE_GAP_DISC_MODE_GEN
             itvl_min: 0x30, // 30 ms, in 0.625 ms units
             itvl_max: 0x60, // 60 ms
             ..Default::default()

--- a/examples/ble_gatt_server.rs
+++ b/examples/ble_gatt_server.rs
@@ -1,0 +1,192 @@
+//! Example of a BLE GATT server using the ESP IDF NimBLE bindings.
+//!
+//! Requires a NimBLE-enabled build.
+
+#![allow(unknown_lints)]
+#![allow(unexpected_cfgs)]
+
+#[cfg(all(not(any(esp32s2, esp32p4)), esp_idf_bt_nimble_enabled))]
+fn main() -> anyhow::Result<()> {
+    example::main()
+}
+
+#[cfg(not(all(not(any(esp32s2, esp32p4)), esp_idf_bt_nimble_enabled)))]
+fn main() -> anyhow::Result<()> {
+    panic!("This example requires a NimBLE-enabled build (CONFIG_BT_NIMBLE_ENABLED=y) on a chip with a BLE radio");
+}
+
+#[cfg(all(not(any(esp32s2, esp32p4)), esp_idf_bt_nimble_enabled))]
+mod example {
+    use core::sync::atomic::{AtomicU16, Ordering};
+    use std::sync::Mutex;
+
+    use esp_idf_svc::ble::gap::{self, BleAdvFields, BleExtAdvParams, BleGapEvent};
+    use esp_idf_svc::ble::gatt::gatts::{
+        self, BleGattAccess, BleGattCharacteristic, BleGattService, BleGattServices, ConnectionId,
+        GattsSetup,
+    };
+    use esp_idf_svc::ble::gatt::BleGattCharFlag;
+    use esp_idf_svc::ble::{ensure_addr, BleError, BleSetup, BleUuid};
+    use esp_idf_svc::hal::delay::FreeRtos;
+    use esp_idf_svc::hal::peripherals::Peripherals;
+    use esp_idf_svc::log::EspLogger;
+
+    use enumset::enum_set;
+    use log::{info, warn};
+
+    const DEVICE_NAME: &str = "esp-nimble";
+    const ADV_INSTANCE: u8 = 0;
+
+    // Our service UUID
+    pub const SERVICE_UUID: u128 = 0xad91b201734740479e173bed82d75f9d;
+
+    /// Our "recv" characteristic - i.e. where clients can send data.
+    pub const RECV_CHARACTERISTIC_UUID: u128 = 0xb6fccb5087be44f3ae22f85485ea42c4;
+    /// Our "indicate" characteristic - i.e. where clients can receive data if they subscribe to it
+    pub const IND_CHARACTERISTIC_UUID: u128 = 0x503de214868246c4828fd59144da41be;
+
+    // Server state. NimBLE fills the value handles during registration.
+    static SUBSCRIBERS: Mutex<Vec<ConnectionId>> = Mutex::new(Vec::new());
+    static RECV_VAL_HANDLE: AtomicU16 = AtomicU16::new(0);
+    static IND_VAL_HANDLE: AtomicU16 = AtomicU16::new(0);
+
+    pub fn main() -> anyhow::Result<()> {
+        esp_idf_svc::sys::link_patches();
+        EspLogger::initialize_default();
+
+        let peripherals = Peripherals::take()?;
+
+        let services = BleGattServices::new(vec![BleGattService::new(
+            true,
+            BleUuid::uuid128(SERVICE_UUID),
+            vec![
+                // "recv": clients write here; we just log what arrives.
+                BleGattCharacteristic::new(
+                    BleUuid::uuid128(RECV_CHARACTERISTIC_UUID),
+                    enum_set!(BleGattCharFlag::Write),
+                    &RECV_VAL_HANDLE,
+                    |access| {
+                        if let BleGattAccess::Write { data, .. } = access {
+                            let mut buf = [0u8; 200];
+                            match data.read(&mut buf) {
+                                Ok(n) => info!("recv {n} bytes: {:?}", &buf[..n]),
+                                Err(e) => warn!("recv read failed: {e}"),
+                            }
+                        }
+                        0
+                    },
+                ),
+                // "indicate": clients subscribe and get the counter pushed from the loop
+                // below. NimBLE adds the CCCD (0x2902) automatically for this flag, so
+                // there is no descriptor to declare and no read/write to service here.
+                BleGattCharacteristic::new(
+                    BleUuid::uuid128(IND_CHARACTERISTIC_UUID),
+                    enum_set!(BleGattCharFlag::Indicate),
+                    &IND_VAL_HANDLE,
+                    |_access| 0,
+                ),
+            ],
+        )]);
+
+        let mut setup = BleSetup::new(peripherals.modem)?;
+
+        GattsSetup::new(&mut setup).add_services(&services)?;
+
+        // We wait until the stack is "in sync" before we can start using it. Note this
+        // closure needs to handle being called multiple times in case the stack resets.
+        setup.on_sync(|| match start_advertising() {
+            Ok(()) => info!("advertising as {DEVICE_NAME:?}"),
+            Err(e) => warn!("failed to start advertising: {e}"),
+        });
+
+        setup.on_gap_event(|event| {
+            match event {
+                BleGapEvent::Connect {
+                    conn_handle,
+                    status,
+                } => info!("connected (handle {conn_handle}): {status:?}"),
+                BleGapEvent::Disconnect {
+                    conn_handle,
+                    reason,
+                } => {
+                    info!("disconnected ({reason}); restarting advertising");
+                    SUBSCRIBERS.lock().unwrap().retain(|&c| c != conn_handle);
+                    if let Err(e) = start_advertising() {
+                        warn!("failed to restart advertising: {e}");
+                    }
+                }
+                BleGapEvent::Subscribe {
+                    conn_handle,
+                    attr_handle,
+                    cur_indicate,
+                    ..
+                } => {
+                    if attr_handle == IND_VAL_HANDLE.load(Ordering::Relaxed) {
+                        let mut subs = SUBSCRIBERS.lock().unwrap();
+                        subs.retain(|&c| c != conn_handle);
+                        if cur_indicate {
+                            let _ = subs.push(conn_handle);
+                        }
+                    }
+                }
+                _ => {}
+            }
+
+            0
+        });
+
+        let _driver = setup.start()?;
+        info!("NimBLE host started");
+
+        let mut counter: u16 = 0;
+        loop {
+            FreeRtos::delay_ms(1000);
+
+            // The handle stays 0 until NimBLE has registered the characteristic.
+            let ind_handle = IND_VAL_HANDLE.load(Ordering::Relaxed);
+            if ind_handle == 0 {
+                continue;
+            }
+
+            counter = counter.wrapping_add(1);
+
+            // Copy the subscriber list out so the lock isn't held across `indicate`.
+            let subs = SUBSCRIBERS.lock().unwrap().clone();
+            for conn in subs {
+                if let Err(e) = gatts::indicate(conn, ind_handle, &counter.to_le_bytes()) {
+                    warn!("indicate to {conn} failed: {e}");
+                }
+            }
+        }
+    }
+
+    /// Configure and start a connectable legacy advertisement.
+    fn start_advertising() -> Result<(), BleError> {
+        ensure_addr(false)?;
+        gap::svc_set_device_name(DEVICE_NAME)?;
+
+        let params = BleExtAdvParams {
+            connectable: true,
+            scannable: true,
+            legacy_pdu: true,
+            itvl_min: 0x30,   // 30 ms, in 0.625 ms units
+            itvl_max: 0x60,   // 60 ms
+            own_addr_type: 0, // BLE_OWN_ADDR_PUBLIC
+            primary_phy: 1,   // BLE_HCI_LE_PHY_1M
+            secondary_phy: 1, // BLE_HCI_LE_PHY_1M
+            tx_power: 127,    // no preference
+            ..Default::default()
+        };
+
+        gap::ext_adv_configure(ADV_INSTANCE, &params)?;
+
+        let fields = BleAdvFields {
+            flags: 0x06, // LE General Discoverable, BR/EDR unsupported
+            name: Some(DEVICE_NAME),
+            ..Default::default()
+        };
+        gap::ext_adv_set_fields(ADV_INSTANCE, &fields)?;
+
+        gap::ext_adv_start(ADV_INSTANCE)
+    }
+}

--- a/examples/ble_gatt_server.rs
+++ b/examples/ble_gatt_server.rs
@@ -22,8 +22,8 @@ mod example {
 
     use esp_idf_svc::ble::gap::{self, BleAdvFields, BleGapEvent};
     use esp_idf_svc::ble::gatt::gatts::{
-        self, BleGattAccess, BleGattCharacteristic, BleGattService, BleGattServices, ConnectionId,
-        GattsSetup,
+        self, BleGattAccess, BleGattCharacteristic, BleGattRegister, BleGattService,
+        BleGattServices, ConnectionId, GattsSetup,
     };
     use esp_idf_svc::ble::gatt::BleGattCharFlag;
     use esp_idf_svc::ble::{ensure_addr, BleError, BleSetup, BleUuid};
@@ -44,9 +44,10 @@ mod example {
     /// Our "indicate" characteristic - i.e. where clients can receive data if they subscribe to it
     pub const IND_CHARACTERISTIC_UUID: u128 = 0x503de214868246c4828fd59144da41be;
 
-    // Server state. NimBLE fills the value handles during registration.
+    // Server state. We capture the indicate characteristic's value handle from the
+    // registration callback (see `on_gatts_register` below); a real server tracking
+    // several handles would keep a uuid -> handle map instead of a single slot.
     static SUBSCRIBERS: Mutex<Vec<ConnectionId>> = Mutex::new(Vec::new());
-    static RECV_VAL_HANDLE: AtomicU16 = AtomicU16::new(0);
     static IND_VAL_HANDLE: AtomicU16 = AtomicU16::new(0);
 
     pub fn main() -> anyhow::Result<()> {
@@ -63,7 +64,6 @@ mod example {
                 BleGattCharacteristic::new(
                     BleUuid::uuid128(RECV_CHARACTERISTIC_UUID),
                     enum_set!(BleGattCharFlag::Write),
-                    &RECV_VAL_HANDLE,
                     |access| {
                         if let BleGattAccess::Write { data, .. } = access {
                             let mut buf = [0u8; 200];
@@ -81,7 +81,6 @@ mod example {
                 BleGattCharacteristic::new(
                     BleUuid::uuid128(IND_CHARACTERISTIC_UUID),
                     enum_set!(BleGattCharFlag::Indicate),
-                    &IND_VAL_HANDLE,
                     |_access| 0,
                 ),
             ],
@@ -90,6 +89,17 @@ mod example {
         let mut setup = BleSetup::new(peripherals.modem)?;
 
         GattsSetup::new(&mut setup).add_services(&services)?;
+
+        // NimBLE assigns attribute handles during registration and reports them here,
+        // on the host task. We stash the indicate handle so the loop below can push to
+        // it; matching on the UUID is how we tell our characteristics apart.
+        setup.on_gatts_register(|event| {
+            if let BleGattRegister::Characteristic { uuid, val_handle, .. } = event {
+                if uuid == BleUuid::uuid128(IND_CHARACTERISTIC_UUID) {
+                    IND_VAL_HANDLE.store(val_handle, Ordering::Relaxed);
+                }
+            }
+        });
 
         // We wait until the stack is "in sync" before we can start using it. Note this
         // closure needs to handle being called multiple times in case the stack resets.
@@ -141,7 +151,8 @@ mod example {
         loop {
             FreeRtos::delay_ms(1000);
 
-            // The handle stays 0 until NimBLE has registered the characteristic.
+            // The handle stays 0 until the GATT registration callback sets it to
+            // whatver val_handle NimBLE assigned.
             let ind_handle = IND_VAL_HANDLE.load(Ordering::Relaxed);
             if ind_handle == 0 {
                 continue;

--- a/examples/ble_gatt_server.rs
+++ b/examples/ble_gatt_server.rs
@@ -20,7 +20,7 @@ mod example {
     use core::sync::atomic::{AtomicU16, Ordering};
     use std::sync::Mutex;
 
-    use esp_idf_svc::ble::gap::{self, BleAdvFields, BleExtAdvParams, BleGapEvent};
+    use esp_idf_svc::ble::gap::{self, BleAdvFields, BleGapEvent};
     use esp_idf_svc::ble::gatt::gatts::{
         self, BleGattAccess, BleGattCharacteristic, BleGattService, BleGattServices, ConnectionId,
         GattsSetup,
@@ -35,7 +35,6 @@ mod example {
     use log::{info, warn};
 
     const DEVICE_NAME: &str = "esp-nimble";
-    const ADV_INSTANCE: u8 = 0;
 
     // Our service UUID
     pub const SERVICE_UUID: u128 = 0xad91b201734740479e173bed82d75f9d;
@@ -160,33 +159,29 @@ mod example {
         }
     }
 
-    /// Configure and start a connectable legacy advertisement.
+    /// Configure and start a connectable legacy advertisement 
+    /// n.b. NimBLE exposes a mutually-exclusive "extended" advertisement API as well
+    /// if you set the right build flags
     fn start_advertising() -> Result<(), BleError> {
+        use esp_idf_svc::ble::gap::BleAdvParams;
+
         ensure_addr(false)?;
         gap::svc_set_device_name(DEVICE_NAME)?;
-
-        let params = BleExtAdvParams {
-            connectable: true,
-            scannable: true,
-            legacy_pdu: true,
-            itvl_min: 0x30,   // 30 ms, in 0.625 ms units
-            itvl_max: 0x60,   // 60 ms
-            own_addr_type: 0, // BLE_OWN_ADDR_PUBLIC
-            primary_phy: 1,   // BLE_HCI_LE_PHY_1M
-            secondary_phy: 1, // BLE_HCI_LE_PHY_1M
-            tx_power: 127,    // no preference
-            ..Default::default()
-        };
-
-        gap::ext_adv_configure(ADV_INSTANCE, &params)?;
 
         let fields = BleAdvFields {
             flags: 0x06, // LE General Discoverable, BR/EDR unsupported
             name: Some(DEVICE_NAME),
             ..Default::default()
         };
-        gap::ext_adv_set_fields(ADV_INSTANCE, &fields)?;
+        gap::adv_set_fields(&fields)?;
 
-        gap::ext_adv_start(ADV_INSTANCE)
+        let params = BleAdvParams {
+            conn_mode: 2, // BLE_GAP_CONN_MODE_UND
+            disc_mode: 2, // BLE_GAP_DISC_MODE_GEN
+            itvl_min: 0x30, // 30 ms, in 0.625 ms units
+            itvl_max: 0x60, // 60 ms
+            ..Default::default()
+        };
+        gap::adv_start(0 /* BLE_OWN_ADDR_PUBLIC */, &params)
     }
 }

--- a/src/ble.rs
+++ b/src/ble.rs
@@ -157,6 +157,45 @@ impl fmt::Display for BleError {
 #[cfg(feature = "std")]
 impl std::error::Error for BleError {}
 
+/// Security Manager (SMP) configuration, applied via
+/// [`BleSetup::set_security`](BleSetup::set_security) before the host starts.
+#[derive(Clone, Copy)]
+pub struct BleSecurity {
+    /// Local IO capabilities (`BLE_HS_IO_*`).
+    pub io_cap: u8,
+    pub oob_data_flag: bool,
+    pub bonding: bool,
+    pub mitm: bool,
+    /// LE Secure Connections.
+    pub secure_connections: bool,
+    /// Restrict pairing to LE Secure Connections only.
+    pub secure_connections_only: bool,
+    pub keypress: bool,
+    /// Minimum GATT security level (`sm_sec_lvl`); 0 is ignored.
+    pub min_sec_level: u8,
+    /// Keys we distribute (`BLE_SM_PAIR_KEY_DIST_*` mask).
+    pub our_key_dist: u8,
+    /// Keys the peer distributes (`BLE_SM_PAIR_KEY_DIST_*` mask).
+    pub their_key_dist: u8,
+}
+
+impl Default for BleSecurity {
+    fn default() -> Self {
+        Self {
+            io_cap: BLE_HS_IO_NO_INPUT_OUTPUT as u8,
+            oob_data_flag: false,
+            bonding: false,
+            mitm: false,
+            secure_connections: false,
+            secure_connections_only: false,
+            keypress: false,
+            min_sec_level: 0,
+            our_key_dist: 0,
+            their_key_dist: 0,
+        }
+    }
+}
+
 #[allow(dead_code)]
 #[allow(clippy::type_complexity)]
 pub(crate) struct BleCallback<A, R> {
@@ -411,6 +450,24 @@ impl<'ble> BleSetup<'ble> {
         F: FnMut(gap::BleGapEvent) -> i32 + Send + 'ble,
     {
         unsafe { SINGLETON.gap_event.subscribe_nonstatic(callback) };
+    }
+
+    /// Configure the Security Manager (SMP) parameters. Must be called before
+    /// [`start`](Self::start); the settings take effect once the host task runs.
+    pub fn set_security(&self, security: &BleSecurity) {
+        unsafe {
+            let cfg = core::ptr::addr_of_mut!(ble_hs_cfg);
+            (*cfg).sm_io_cap = security.io_cap;
+            (*cfg).set_sm_oob_data_flag(security.oob_data_flag as _);
+            (*cfg).set_sm_bonding(security.bonding as _);
+            (*cfg).set_sm_mitm(security.mitm as _);
+            (*cfg).set_sm_sc(security.secure_connections as _);
+            (*cfg).set_sm_sc_only(security.secure_connections_only as _);
+            (*cfg).set_sm_keypress(security.keypress as _);
+            (*cfg).sm_sec_lvl = security.min_sec_level;
+            (*cfg).sm_our_key_dist = security.our_key_dist;
+            (*cfg).sm_their_key_dist = security.their_key_dist;
+        }
     }
 
     /// Once you are done with setup, call this function to start the BLE task. The task will

--- a/src/ble.rs
+++ b/src/ble.rs
@@ -1,0 +1,426 @@
+//! Safe wrapper for the ESP-IDF NimBLE BLE host.
+
+use core::cell::UnsafeCell;
+use core::ffi::{c_int, c_void};
+use core::fmt;
+use core::marker::PhantomData;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+
+use crate::hal::modem::BluetoothModemPeripheral;
+use crate::private::mutex::Mutex;
+use crate::sys::*;
+
+pub mod gap;
+pub mod gatt;
+pub mod mbuf;
+
+/// A BLE UUID, either 16-bit (assigned) or 128-bit (vendor-specific).
+#[derive(Clone, Copy, Debug)]
+pub enum BleUuid {
+    Uuid16(ble_uuid16_t),
+    Uuid128(ble_uuid128_t),
+}
+
+impl BleUuid {
+    pub const fn uuid16(uuid: u16) -> Self {
+        Self::Uuid16(ble_uuid16_t {
+            u: ble_uuid_t {
+                type_: BLE_UUID_TYPE_16 as u8,
+            },
+            value: uuid,
+        })
+    }
+
+    pub const fn uuid128(uuid: u128) -> Self {
+        Self::Uuid128(ble_uuid128_t {
+            u: ble_uuid_t {
+                type_: BLE_UUID_TYPE_128 as u8,
+            },
+            value: uuid.to_le_bytes(),
+        })
+    }
+
+    pub fn as_ptr(&self) -> *const ble_uuid_t {
+        match self {
+            Self::Uuid16(uuid) => &uuid.u as *const ble_uuid_t,
+            Self::Uuid128(uuid) => &uuid.u as *const ble_uuid_t,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct BleAddr(ble_addr_t);
+
+impl BleAddr {
+    pub const fn new(kind: u8, val: [u8; 6]) -> Self {
+        Self(ble_addr_t { type_: kind, val })
+    }
+
+    pub const fn raw(&self) -> &ble_addr_t {
+        &self.0
+    }
+
+    pub const fn kind(&self) -> u8 {
+        self.0.type_
+    }
+
+    pub const fn val(&self) -> [u8; 6] {
+        self.0.val
+    }
+}
+
+impl fmt::Display for BleAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let v = &self.0.val;
+        write!(
+            f,
+            "{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
+            v[5], v[4], v[3], v[2], v[1], v[0]
+        )
+    }
+}
+
+impl From<ble_addr_t> for BleAddr {
+    fn from(addr: ble_addr_t) -> Self {
+        Self(addr)
+    }
+}
+
+impl From<BleAddr> for ble_addr_t {
+    fn from(addr: BleAddr) -> Self {
+        addr.0
+    }
+}
+
+/// Attempt to configure at least one BLE address; how this is done is hardware-specific.
+/// If prefer_random is true, prefer using a random address even if a public address is configured.
+pub fn ensure_addr(prefer_random: bool) -> Result<(), BleError> {
+    BleError::from_raw(unsafe { ble_hs_util_ensure_addr(prefer_random as c_int) })
+}
+
+/// Read back the device's identity address of the given type.
+pub fn id_copy_addr(kind: u8) -> BleAddr {
+    let mut val = [0u8; 6];
+    let _ = unsafe { ble_hs_id_copy_addr(kind, val.as_mut_ptr(), core::ptr::null_mut()) };
+
+    BleAddr::new(kind, val)
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct BleError(c_int);
+
+impl BleError {
+    pub const fn new(rc: c_int) -> Self {
+        Self(rc)
+    }
+
+    pub const fn code(&self) -> c_int {
+        self.0
+    }
+
+    pub fn from_raw(rc: c_int) -> Result<(), Self> {
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(Self(rc))
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        match self.0 as u32 {
+            BLE_HS_EALREADY => "BLE_HS_EALREADY",
+            BLE_HS_EDONE => "BLE_HS_EDONE",
+            BLE_HS_ENOMEM => "BLE_HS_ENOMEM",
+            BLE_HS_ETIMEOUT => "BLE_HS_ETIMEOUT",
+            _ => "BLE_HS_E*",
+        }
+    }
+}
+
+impl fmt::Debug for BleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "BleError({}, {})", self.0, self.name())
+    }
+}
+
+impl fmt::Display for BleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "NimBLE error {} ({})", self.0, self.name())
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for BleError {}
+
+#[allow(dead_code)]
+#[allow(clippy::type_complexity)]
+pub(crate) struct BleCallback<A, R> {
+    callback: Mutex<Option<Arc<UnsafeCell<Box<dyn FnMut(A) -> R>>>>>,
+    default_result: R,
+}
+
+#[allow(dead_code)]
+impl<A, R> BleCallback<A, R>
+where
+    R: Clone,
+{
+    pub const fn new(default_result: R) -> Self {
+        Self {
+            callback: Mutex::new(None),
+            default_result,
+        }
+    }
+
+    pub fn subscribe<F>(&self, callback: F)
+    where
+        F: FnMut(A) -> R + Send + 'static,
+    {
+        unsafe { self.subscribe_nonstatic(callback) }
+    }
+
+    /// # Safety
+    ///
+    /// The stored slot is `'static`; this erases the callback's lifetime. The
+    /// caller must ensure the callback (and everything it borrows) stays valid
+    /// until it is unsubscribed via `unsubscribe`.
+    pub unsafe fn subscribe_nonstatic<'a, F>(&self, callback: F)
+    where
+        F: FnMut(A) -> R + Send + 'a,
+    {
+        let callback: Box<dyn FnMut(A) -> R + 'a> = Box::new(callback);
+        let callback: Box<dyn FnMut(A) -> R + 'static> = unsafe { core::mem::transmute(callback) };
+        *self.callback.lock() = Some(Arc::new(UnsafeCell::new(callback)));
+    }
+
+    pub fn unsubscribe(&self) {
+        *self.callback.lock() = None;
+    }
+
+    /// # Safety
+    ///
+    /// Safe to use only from within the NimBLE host task.
+    pub unsafe fn call(&self, arg: A) -> R {
+        if let Some(callback) = self
+            .callback
+            .lock()
+            .as_ref()
+            .map(|callback| callback.clone())
+        {
+            ((callback.get()).as_mut().unwrap())(arg)
+        } else {
+            self.default_result.clone()
+        }
+    }
+}
+
+unsafe impl<A, R> Sync for BleCallback<A, R> {}
+unsafe impl<A, R> Send for BleCallback<A, R> {}
+
+/// The NimBLE stack has several globally-singleton things; we enforce that by
+/// the calling take/release on this. BleSingleton also wraps the globally singleton state
+/// that requires well-known static addresses.
+#[allow(dead_code)]
+pub(crate) struct BleSingleton {
+    initialized: AtomicBool,
+    sync: BleCallback<(), ()>,
+    reset: BleCallback<i32, ()>,
+    gap_event: BleCallback<gap::BleGapEvent, i32>,
+}
+
+#[allow(dead_code)]
+impl BleSingleton {
+    pub const fn new() -> Self {
+        Self {
+            initialized: AtomicBool::new(false),
+            sync: BleCallback::new(()),
+            reset: BleCallback::new(()),
+            gap_event: BleCallback::new(0),
+        }
+    }
+
+    pub fn take(&self) -> Result<(), EspError> {
+        self.initialized
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .map_err(|_| EspError::from_infallible::<ESP_ERR_INVALID_STATE>())?;
+
+        Ok(())
+    }
+
+    pub fn release(&self) -> Result<(), EspError> {
+        self.initialized
+            .compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst)
+            .map_err(|_| EspError::from_infallible::<ESP_ERR_INVALID_STATE>())?;
+
+        Ok(())
+    }
+}
+
+static SINGLETON: BleSingleton = BleSingleton::new();
+
+unsafe extern "C" fn host_sync_cb() {
+    unsafe { SINGLETON.sync.call(()) }
+}
+
+unsafe extern "C" fn host_reset_cb(reason: i32) {
+    unsafe { SINGLETON.reset.call(reason) }
+}
+
+unsafe extern "C" fn gap_event_cb(event: *mut ble_gap_event, _arg: *mut c_void) -> c_int {
+    let event = gap::BleGapEvent::from(unsafe { &*event });
+
+    unsafe { SINGLETON.gap_event.call(event) }
+}
+
+unsafe extern "C" fn host_task(_arg: *mut c_void) {
+    unsafe {
+        nimble_port_run();
+        nimble_port_freertos_deinit();
+    }
+}
+
+/// The NimBLE host handle, use BleSetup to create this. The BLE stack stays up until
+/// this is dropped. There can only be one of these at a time.
+pub struct BleDriver<'ble> {
+    started: bool,
+    _p: PhantomData<&'ble mut ()>,
+}
+
+impl Drop for BleDriver<'_> {
+    fn drop(&mut self) {
+        if self.started {
+            let _ = unsafe { nimble_port_stop() };
+        }
+
+        esp!(unsafe { nimble_port_deinit() }).unwrap();
+
+        unsafe {
+            let cfg = core::ptr::addr_of_mut!(ble_hs_cfg);
+            (*cfg).sync_cb = None;
+            (*cfg).reset_cb = None;
+        }
+
+        SINGLETON.sync.unsubscribe();
+        SINGLETON.reset.unsubscribe();
+        SINGLETON.gap_event.unsubscribe();
+        let _ = SINGLETON.release();
+    }
+}
+
+/// This is your primary entrypoint to setup BLE. Create a new instance of this, set up
+/// callbacks and then start it to get the driver instance.
+pub struct BleSetup<'ble> {
+    driver: BleDriver<'ble>,
+}
+
+impl<'ble> BleSetup<'ble> {
+    pub fn new<M: BluetoothModemPeripheral + 'ble>(_modem: M) -> Result<Self, EspError> {
+        SINGLETON.take()?;
+
+        esp!(unsafe { nimble_port_init() })?;
+
+        unsafe {
+            ble_svc_gap_init();
+            ble_svc_gatt_init();
+        }
+
+        Ok(Self {
+            driver: BleDriver {
+                started: false,
+                _p: PhantomData,
+            },
+        })
+    }
+
+    /// Once the BLE stack is "in sync", this gets called; you should delay BLE operations until
+    /// this gets called. Note the stack can also go out-of-sync for various reasons, indicated by
+    /// on_reset being called followed by this being called again, so the callback must be re-entrant.
+    /// See https://mynewt.apache.org/latest/network/ble_setup/ble_sync_cb.html
+    pub fn on_sync<F>(&self, callback: F)
+    where
+        F: FnMut() + Send + 'static,
+    {
+        unsafe { self.on_sync_nonstatic(callback) }
+    }
+
+    /// # Safety
+    ///
+    /// This method - in contrast to `on_sync` - allows a non-`'static` callback,
+    /// so it may borrow variables that live as long as the [`BleDriver`] returned
+    /// by `start`. The callback stays registered with the running NimBLE host task
+    /// until the driver is dropped, which un-subscribes it.
+    ///
+    /// Care must be taken NOT to `core::mem::forget` the driver: that skips the
+    /// un-subscription, leaving the host task holding a callback with dangling
+    /// borrows. This "local borrowing" can only be expressed safely once/if `!Leak`
+    /// types are introduced to Rust.
+    pub unsafe fn on_sync_nonstatic<F>(&self, mut callback: F)
+    where
+        F: FnMut() + Send + 'ble,
+    {
+        unsafe { SINGLETON.sync.subscribe_nonstatic(move |()| callback()) };
+
+        unsafe {
+            (*core::ptr::addr_of_mut!(ble_hs_cfg)).sync_cb = Some(host_sync_cb);
+        }
+    }
+
+    /// Called if the BLE host goes out of sync with the controller after on_sync has been called.
+    /// See https://mynewt.apache.org/latest/network/ble_setup/ble_sync_cb.html
+    pub fn on_reset<F>(&self, callback: F)
+    where
+        F: FnMut(i32) + Send + 'static,
+    {
+        unsafe { self.on_reset_nonstatic(callback) }
+    }
+
+    /// # Safety
+    ///
+    /// The non-`'static` counterpart of `on_reset`. See
+    /// [`on_sync_nonstatic`](Self::on_sync_nonstatic) for the borrowing rules and
+    /// the `core::mem::forget` hazard.
+    pub unsafe fn on_reset_nonstatic<F>(&self, callback: F)
+    where
+        F: FnMut(i32) + Send + 'ble,
+    {
+        unsafe { SINGLETON.reset.subscribe_nonstatic(callback) };
+
+        unsafe {
+            (*core::ptr::addr_of_mut!(ble_hs_cfg)).reset_cb = Some(host_reset_cb);
+        }
+    }
+
+    pub fn on_gap_event<F>(&self, callback: F)
+    where
+        F: FnMut(gap::BleGapEvent) -> i32 + Send + 'static,
+    {
+        unsafe { self.on_gap_event_nonstatic(callback) }
+    }
+
+    /// # Safety
+    ///
+    /// The non-`'static` counterpart of `on_gap_event`. See
+    /// [`on_sync_nonstatic`](Self::on_sync_nonstatic) for the borrowing rules and
+    /// the `core::mem::forget` hazard.
+    pub unsafe fn on_gap_event_nonstatic<F>(&self, callback: F)
+    where
+        F: FnMut(gap::BleGapEvent) -> i32 + Send + 'ble,
+    {
+        unsafe { SINGLETON.gap_event.subscribe_nonstatic(callback) };
+    }
+
+    /// Once you are done with setup, call this function to start the BLE task. The task will
+    /// start in the background and call [`on_sync`](Self::on_sync) once it's ready for use.
+    /// You must retain the driver, the BLE stack is stopped when it drops.
+    pub fn start(mut self) -> Result<BleDriver<'ble>, EspError> {
+        unsafe { nimble_port_freertos_init(Some(host_task)) };
+
+        self.driver.started = true;
+
+        Ok(self.driver)
+    }
+}

--- a/src/ble.rs
+++ b/src/ble.rs
@@ -179,6 +179,15 @@ impl fmt::Display for BleError {
 #[cfg(feature = "std")]
 impl std::error::Error for BleError {}
 
+impl From<BleError> for EspError {
+    /// NimBLE host codes (`BLE_HS_E*`) are a separate namespace from `esp_err_t`
+    /// with no faithful mapping, so any [`BleError`] collapses to `ESP_FAIL`. Match
+    /// on the [`BleError`] directly if you need the specific NimBLE code.
+    fn from(_err: BleError) -> Self {
+        EspError::from_infallible::<ESP_FAIL>()
+    }
+}
+
 /// Security Manager (SMP) configuration, applied via
 /// [`BleSetup::set_security`](BleSetup::set_security) before the host starts.
 #[derive(Clone, Copy)]

--- a/src/ble.rs
+++ b/src/ble.rs
@@ -103,11 +103,13 @@ pub fn ensure_addr(prefer_random: bool) -> Result<(), BleError> {
 }
 
 /// Read back the device's identity address of the given type.
-pub fn id_copy_addr(kind: u8) -> BleAddr {
+pub fn id_copy_addr(kind: u8) -> Result<BleAddr, BleError> {
     let mut val = [0u8; 6];
-    let _ = unsafe { ble_hs_id_copy_addr(kind, val.as_mut_ptr(), core::ptr::null_mut()) };
+    BleError::from_raw(unsafe {
+        ble_hs_id_copy_addr(kind, val.as_mut_ptr(), core::ptr::null_mut())
+    })?;
 
-    BleAddr::new(kind, val)
+    Ok(BleAddr::new(kind, val))
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/src/ble.rs
+++ b/src/ble.rs
@@ -49,7 +49,27 @@ impl BleUuid {
             Self::Uuid128(uuid) => &uuid.u as *const ble_uuid_t,
         }
     }
+
+    /// # Safety
+    ///
+    /// `uuid` must point to a valid `ble_uuid_t` header and the concrete
+    /// 16-/128-bit body it introduces.
+    pub(crate) unsafe fn from_raw(uuid: *const ble_uuid_t) -> Self {
+        match unsafe { (*uuid).type_ } as u32 {
+            BLE_UUID_TYPE_128 => Self::Uuid128(unsafe { *uuid.cast::<ble_uuid128_t>() }),
+            // Only 16- and 128-bit UUIDs are modelled; anything else reads as 16-bit.
+            _ => Self::Uuid16(unsafe { *uuid.cast::<ble_uuid16_t>() }),
+        }
+    }
 }
+
+impl PartialEq for BleUuid {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { ble_uuid_cmp(self.as_ptr(), other.as_ptr()) == 0 }
+    }
+}
+
+impl Eq for BleUuid {}
 
 #[derive(Clone, Copy)]
 #[repr(transparent)]
@@ -271,6 +291,7 @@ pub(crate) struct BleSingleton {
     sync: BleCallback<(), ()>,
     reset: BleCallback<i32, ()>,
     gap_event: BleCallback<gap::BleGapEvent, i32>,
+    gatts_register: BleCallback<gatt::gatts::BleGattRegister, ()>,
 }
 
 #[allow(dead_code)]
@@ -281,6 +302,7 @@ impl BleSingleton {
             sync: BleCallback::new(()),
             reset: BleCallback::new(()),
             gap_event: BleCallback::new(0),
+            gatts_register: BleCallback::new(()),
         }
     }
 
@@ -317,6 +339,12 @@ unsafe extern "C" fn gap_event_cb(event: *mut ble_gap_event, _arg: *mut c_void) 
     unsafe { SINGLETON.gap_event.call(event) }
 }
 
+unsafe extern "C" fn gatts_register_cb(ctxt: *mut ble_gatt_register_ctxt, _arg: *mut c_void) {
+    let event = gatt::gatts::BleGattRegister::from(unsafe { &*ctxt });
+
+    unsafe { SINGLETON.gatts_register.call(event) }
+}
+
 unsafe extern "C" fn host_task(_arg: *mut c_void) {
     unsafe {
         nimble_port_run();
@@ -343,11 +371,13 @@ impl Drop for BleDriver<'_> {
             let cfg = core::ptr::addr_of_mut!(ble_hs_cfg);
             (*cfg).sync_cb = None;
             (*cfg).reset_cb = None;
+            (*cfg).gatts_register_cb = None;
         }
 
         SINGLETON.sync.unsubscribe();
         SINGLETON.reset.unsubscribe();
         SINGLETON.gap_event.unsubscribe();
+        SINGLETON.gatts_register.unsubscribe();
         let _ = SINGLETON.release();
     }
 }
@@ -452,6 +482,32 @@ impl<'ble> BleSetup<'ble> {
         F: FnMut(gap::BleGapEvent) -> i32 + Send + 'ble,
     {
         unsafe { SINGLETON.gap_event.subscribe_nonstatic(callback) };
+    }
+
+    /// Called on the host task as each GATT service, characteristic, and descriptor
+    /// is registered, carrying the attribute handles NimBLE assigned. Capture the
+    /// value handles you need here (e.g. by UUID).
+    pub fn on_gatts_register<F>(&self, callback: F)
+    where
+        F: FnMut(gatt::gatts::BleGattRegister) + Send + 'static,
+    {
+        unsafe { self.on_gatts_register_nonstatic(callback) }
+    }
+
+    /// # Safety
+    ///
+    /// The non-`'static` counterpart of `on_gatts_register`. See
+    /// [`on_sync_nonstatic`](Self::on_sync_nonstatic) for the borrowing rules and
+    /// the `core::mem::forget` hazard.
+    pub unsafe fn on_gatts_register_nonstatic<F>(&self, callback: F)
+    where
+        F: FnMut(gatt::gatts::BleGattRegister) + Send + 'ble,
+    {
+        unsafe { SINGLETON.gatts_register.subscribe_nonstatic(callback) };
+
+        unsafe {
+            (*core::ptr::addr_of_mut!(ble_hs_cfg)).gatts_register_cb = Some(gatts_register_cb);
+        }
     }
 
     /// Configure the Security Manager (SMP) parameters. Must be called before

--- a/src/ble/gap.rs
+++ b/src/ble/gap.rs
@@ -1,0 +1,262 @@
+//! NimBLE GAP: device name, connection events, and extended advertising.
+
+use core::ffi::c_int;
+use core::ptr;
+
+use alloc::ffi::CString;
+
+use crate::sys::*;
+
+use super::gatt::gatts::ConnectionId;
+use super::gatt::Handle;
+use super::{BleAddr, BleError};
+
+/// Set the device name exposed via the GAP service.
+pub fn svc_set_device_name(name: &str) -> Result<(), BleError> {
+    let name = CString::new(name).map_err(|_| BleError::new(BLE_HS_EINVAL as c_int))?;
+
+    // NimBLE copies the name into its own buffer, so the drop is safe
+    BleError::from_raw(unsafe { ble_svc_gap_device_name_set(name.as_ptr()) })
+}
+
+/// Parameters for an extended advertising instance (safe version of `ble_gap_ext_adv_params`).
+#[derive(Clone, Copy, Default)]
+pub struct BleExtAdvParams {
+    pub connectable: bool,
+    pub scannable: bool,
+    pub legacy_pdu: bool,
+    pub directed: bool,
+    pub anonymous: bool,
+    pub high_duty_directed: bool,
+    pub include_tx_power: bool,
+    pub itvl_min: u32,
+    pub itvl_max: u32,
+    pub channel_map: u8,
+    pub own_addr_type: u8,
+    pub primary_phy: u8,
+    pub secondary_phy: u8,
+    pub tx_power: i8,
+    pub sid: u8,
+}
+
+impl From<&BleExtAdvParams> for ble_gap_ext_adv_params {
+    fn from(params: &BleExtAdvParams) -> Self {
+        let mut raw: ble_gap_ext_adv_params = unsafe { core::mem::zeroed() };
+
+        raw.set_connectable(params.connectable as _);
+        raw.set_scannable(params.scannable as _);
+        raw.set_legacy_pdu(params.legacy_pdu as _);
+        raw.set_directed(params.directed as _);
+        raw.set_anonymous(params.anonymous as _);
+        raw.set_high_duty_directed(params.high_duty_directed as _);
+        raw.set_include_tx_power(params.include_tx_power as _);
+
+        raw.itvl_min = params.itvl_min;
+        raw.itvl_max = params.itvl_max;
+        raw.channel_map = params.channel_map;
+        raw.own_addr_type = params.own_addr_type;
+        raw.primary_phy = params.primary_phy;
+        raw.secondary_phy = params.secondary_phy;
+        raw.tx_power = params.tx_power;
+        raw.sid = params.sid;
+
+        raw
+    }
+}
+
+/// Structured advertising payload (safe version of `ble_hs_adv_fields`).
+/// You can also directly use ext_adv_set_data to set the raw data yourself.
+#[derive(Clone, Copy, Default)]
+pub struct BleAdvFields<'a> {
+    pub flags: u8,
+    pub name: Option<&'a str>,
+    pub tx_power_level: Option<i8>,
+    pub appearance: Option<u16>,
+    pub service_data_uuid16: Option<&'a [u8]>,
+    pub manufacturer_data: Option<&'a [u8]>,
+}
+
+impl From<&BleAdvFields<'_>> for ble_hs_adv_fields {
+    fn from(fields: &BleAdvFields) -> Self {
+        let mut raw: ble_hs_adv_fields = unsafe { core::mem::zeroed() };
+
+        raw.flags = fields.flags;
+
+        if let Some(name) = fields.name {
+            raw.name = name.as_ptr();
+            raw.name_len = name.len() as _;
+            raw.set_name_is_complete(1);
+        }
+
+        if let Some(tx_power_level) = fields.tx_power_level {
+            raw.tx_pwr_lvl = tx_power_level;
+            raw.set_tx_pwr_lvl_is_present(1);
+        }
+
+        if let Some(appearance) = fields.appearance {
+            raw.appearance = appearance;
+            raw.set_appearance_is_present(1);
+        }
+
+        if let Some(service_data) = fields.service_data_uuid16 {
+            raw.svc_data_uuid16 = service_data.as_ptr();
+            raw.svc_data_uuid16_len = service_data.len() as _;
+        }
+
+        if let Some(manufacturer_data) = fields.manufacturer_data {
+            raw.mfg_data = manufacturer_data.as_ptr();
+            raw.mfg_data_len = manufacturer_data.len() as _;
+        }
+
+        raw
+    }
+}
+
+pub enum BleGapEvent {
+    Connect {
+        conn_handle: ConnectionId,
+        status: Result<(), BleError>,
+    },
+    Disconnect {
+        conn_handle: ConnectionId,
+        reason: BleError,
+    },
+    Subscribe {
+        conn_handle: ConnectionId,
+        attr_handle: Handle,
+        cur_indicate: bool,
+        cur_notify: bool,
+    },
+    Mtu {
+        conn_handle: ConnectionId,
+        value: u16,
+    },
+    NotifyTx {
+        conn_handle: ConnectionId,
+        status: i32,
+    },
+    Other,
+}
+
+impl From<&ble_gap_event> for BleGapEvent {
+    fn from(event: &ble_gap_event) -> Self {
+        let anon = &event.__bindgen_anon_1;
+
+        match event.type_ as u32 {
+            BLE_GAP_EVENT_CONNECT => {
+                let connect = unsafe { &anon.connect };
+                Self::Connect {
+                    conn_handle: connect.conn_handle,
+                    status: BleError::from_raw(connect.status),
+                }
+            }
+            BLE_GAP_EVENT_DISCONNECT => {
+                let disconnect = unsafe { &anon.disconnect };
+                Self::Disconnect {
+                    conn_handle: disconnect.conn.conn_handle,
+                    reason: BleError::new(disconnect.reason),
+                }
+            }
+            BLE_GAP_EVENT_SUBSCRIBE => {
+                let subscribe = unsafe { &anon.subscribe };
+                Self::Subscribe {
+                    conn_handle: subscribe.conn_handle,
+                    attr_handle: subscribe.attr_handle,
+                    cur_indicate: subscribe.cur_indicate() != 0,
+                    cur_notify: subscribe.cur_notify() != 0,
+                }
+            }
+            BLE_GAP_EVENT_MTU => {
+                let mtu = unsafe { &anon.mtu };
+                Self::Mtu {
+                    conn_handle: mtu.conn_handle,
+                    value: mtu.value,
+                }
+            }
+            BLE_GAP_EVENT_NOTIFY_TX => {
+                let notify_tx = unsafe { &anon.notify_tx };
+                Self::NotifyTx {
+                    conn_handle: notify_tx.conn_handle,
+                    status: notify_tx.status,
+                }
+            }
+            _ => Self::Other,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct BleConnDesc(ble_gap_conn_desc);
+
+impl BleConnDesc {
+    pub const fn peer_addr(&self) -> BleAddr {
+        BleAddr::new(self.0.peer_id_addr.type_, self.0.peer_id_addr.val)
+    }
+}
+
+/// Look up a connection descriptor by handle.
+pub fn conn_find(conn_handle: ConnectionId) -> Result<BleConnDesc, BleError> {
+    let mut desc: ble_gap_conn_desc = unsafe { core::mem::zeroed() };
+    BleError::from_raw(unsafe { ble_gap_conn_find(conn_handle, &mut desc) })?;
+
+    Ok(BleConnDesc(desc))
+}
+
+// Extended advertising. Drive these from an `on_sync` closure once the host has
+// synced, and restart from an `on_gap_event` disconnect handler.
+
+/// Configure extended-advertising `instance` and return the controller-selected
+/// TX power.
+pub fn ext_adv_configure(instance: u8, params: &BleExtAdvParams) -> Result<i8, BleError> {
+    let raw: ble_gap_ext_adv_params = params.into();
+    let mut selected_tx_power: i8 = 0;
+
+    BleError::from_raw(unsafe {
+        ble_gap_ext_adv_configure(
+            instance,
+            &raw,
+            &mut selected_tx_power,
+            Some(super::gap_event_cb),
+            ptr::null_mut(),
+        )
+    })?;
+
+    Ok(selected_tx_power)
+}
+
+pub fn ext_adv_set_addr(instance: u8, addr: &BleAddr) -> Result<(), BleError> {
+    BleError::from_raw(unsafe { ble_gap_ext_adv_set_addr(instance, addr.raw()) })
+}
+
+pub fn ext_adv_set_data(instance: u8, data: &[u8]) -> Result<(), BleError> {
+    let om = super::mbuf::mbuf_from_slice(data)?;
+
+    BleError::from_raw(unsafe { ble_gap_ext_adv_set_data(instance, om) })
+}
+
+/// Encode `fields` into an advertising payload and install it on `instance`.
+pub fn ext_adv_set_fields(instance: u8, fields: &BleAdvFields) -> Result<(), BleError> {
+    let raw: ble_hs_adv_fields = fields.into();
+
+    let mut buf = [0u8; BLE_HS_ADV_MAX_SZ as usize];
+    let mut len: u8 = 0;
+    BleError::from_raw(unsafe {
+        ble_hs_adv_set_fields(&raw, buf.as_mut_ptr(), &mut len, buf.len() as u8)
+    })?;
+
+    ext_adv_set_data(instance, &buf[..len as usize])
+}
+
+pub fn ext_adv_start(instance: u8) -> Result<(), BleError> {
+    let rc = unsafe { ble_gap_ext_adv_start(instance, 0, 0) };
+    if rc == BLE_HS_EALREADY as c_int {
+        return Ok(());
+    }
+
+    BleError::from_raw(rc)
+}
+
+pub fn ext_adv_stop(instance: u8) -> Result<(), BleError> {
+    BleError::from_raw(unsafe { ble_gap_ext_adv_stop(instance) })
+}

--- a/src/ble/gap.rs
+++ b/src/ble/gap.rs
@@ -19,7 +19,50 @@ pub fn svc_set_device_name(name: &str) -> Result<(), BleError> {
     BleError::from_raw(unsafe { ble_svc_gap_device_name_set(name.as_ptr()) })
 }
 
+
+
+// Advertising. Drive these from an `on_sync` closure once the host has synced,
+// and restart from an `on_gap_event` disconnect handler.
+//
+// NimBLE exposes two mutually-exclusive advertising APIs. The legacy API below is
+// the default; the extended API (`ext_adv_*`) is only compiled when the controller
+// is built with `CONFIG_BT_NIMBLE_EXT_ADV=y`.
+
+/// Parameters for a legacy advertising procedure (safe version of `ble_gap_adv_params`).
+#[cfg(not(esp_idf_bt_nimble_ext_adv))]
+#[derive(Clone, Copy, Default)]
+pub struct BleAdvParams {
+    pub conn_mode: u8,
+    pub disc_mode: u8,
+    pub itvl_min: u16,
+    pub itvl_max: u16,
+    pub channel_map: u8,
+    pub filter_policy: u8,
+    pub high_duty_cycle: bool,
+}
+
+#[cfg(not(esp_idf_bt_nimble_ext_adv))]
+impl From<&BleAdvParams> for ble_gap_adv_params {
+    fn from(params: &BleAdvParams) -> Self {
+        let mut raw: ble_gap_adv_params = unsafe { core::mem::zeroed() };
+
+        raw.conn_mode = params.conn_mode;
+        raw.disc_mode = params.disc_mode;
+        raw.itvl_min = params.itvl_min;
+        raw.itvl_max = params.itvl_max;
+        raw.channel_map = params.channel_map;
+        raw.filter_policy = params.filter_policy;
+        raw.high_duty_cycle = params.high_duty_cycle as _;
+
+        raw
+    }
+}
+
 /// Parameters for an extended advertising instance (safe version of `ble_gap_ext_adv_params`).
+///
+/// Only available when the controller is built with `CONFIG_BT_NIMBLE_EXT_ADV=y`;
+/// the default build exposes the legacy [`BleAdvParams`].
+#[cfg(esp_idf_bt_nimble_ext_adv)]
 #[derive(Clone, Copy, Default)]
 pub struct BleExtAdvParams {
     pub connectable: bool,
@@ -39,6 +82,7 @@ pub struct BleExtAdvParams {
     pub sid: u8,
 }
 
+#[cfg(esp_idf_bt_nimble_ext_adv)]
 impl From<&BleExtAdvParams> for ble_gap_ext_adv_params {
     fn from(params: &BleExtAdvParams) -> Self {
         let mut raw: ble_gap_ext_adv_params = unsafe { core::mem::zeroed() };
@@ -65,7 +109,7 @@ impl From<&BleExtAdvParams> for ble_gap_ext_adv_params {
 }
 
 /// Structured advertising payload (safe version of `ble_hs_adv_fields`).
-/// You can also directly use ext_adv_set_data to set the raw data yourself.
+/// You can also directly use ext_adv_set_data/adv_set_data to set the raw data yourself.
 #[derive(Clone, Copy, Default)]
 pub struct BleAdvFields<'a> {
     pub flags: u8,
@@ -203,11 +247,46 @@ pub fn conn_find(conn_handle: ConnectionId) -> Result<BleConnDesc, BleError> {
     Ok(BleConnDesc(desc))
 }
 
-// Extended advertising. Drive these from an `on_sync` closure once the host has
-// synced, and restart from an `on_gap_event` disconnect handler.
+#[cfg(not(esp_idf_bt_nimble_ext_adv))]
+pub fn adv_set_data(data: &[u8]) -> Result<(), BleError> {
+    // NimBLE copies the payload into its own buffer, so `data` need not outlive the call.
+    BleError::from_raw(unsafe { ble_gap_adv_set_data(data.as_ptr(), data.len() as c_int) })
+}
 
-/// Configure extended-advertising `instance` and return the controller-selected
-/// TX power.
+#[cfg(not(esp_idf_bt_nimble_ext_adv))]
+pub fn adv_set_fields(fields: &BleAdvFields) -> Result<(), BleError> {
+    let raw: ble_hs_adv_fields = fields.into();
+
+    BleError::from_raw(unsafe { ble_gap_adv_set_fields(&raw) })
+}
+
+#[cfg(not(esp_idf_bt_nimble_ext_adv))]
+pub fn adv_start(own_addr_type: u8, params: &BleAdvParams) -> Result<(), BleError> {
+    let raw: ble_gap_adv_params = params.into();
+
+    let rc = unsafe {
+        ble_gap_adv_start(
+            own_addr_type,
+            ptr::null(),
+            BLE_HS_FOREVER as _,
+            &raw,
+            Some(super::gap_event_cb),
+            ptr::null_mut(),
+        )
+    };
+    if rc == BLE_HS_EALREADY as c_int {
+        return Ok(());
+    }
+
+    BleError::from_raw(rc)
+}
+
+#[cfg(not(esp_idf_bt_nimble_ext_adv))]
+pub fn adv_stop() -> Result<(), BleError> {
+    BleError::from_raw(unsafe { ble_gap_adv_stop() })
+}
+
+#[cfg(esp_idf_bt_nimble_ext_adv)]
 pub fn ext_adv_configure(instance: u8, params: &BleExtAdvParams) -> Result<i8, BleError> {
     let raw: ble_gap_ext_adv_params = params.into();
     let mut selected_tx_power: i8 = 0;
@@ -225,10 +304,12 @@ pub fn ext_adv_configure(instance: u8, params: &BleExtAdvParams) -> Result<i8, B
     Ok(selected_tx_power)
 }
 
+#[cfg(esp_idf_bt_nimble_ext_adv)]
 pub fn ext_adv_set_addr(instance: u8, addr: &BleAddr) -> Result<(), BleError> {
     BleError::from_raw(unsafe { ble_gap_ext_adv_set_addr(instance, addr.raw()) })
 }
 
+#[cfg(esp_idf_bt_nimble_ext_adv)]
 pub fn ext_adv_set_data(instance: u8, data: &[u8]) -> Result<(), BleError> {
     let om = super::mbuf::mbuf_from_slice(data)?;
 
@@ -236,6 +317,7 @@ pub fn ext_adv_set_data(instance: u8, data: &[u8]) -> Result<(), BleError> {
 }
 
 /// Encode `fields` into an advertising payload and install it on `instance`.
+#[cfg(esp_idf_bt_nimble_ext_adv)]
 pub fn ext_adv_set_fields(instance: u8, fields: &BleAdvFields) -> Result<(), BleError> {
     let raw: ble_hs_adv_fields = fields.into();
 
@@ -248,6 +330,7 @@ pub fn ext_adv_set_fields(instance: u8, fields: &BleAdvFields) -> Result<(), Ble
     ext_adv_set_data(instance, &buf[..len as usize])
 }
 
+#[cfg(esp_idf_bt_nimble_ext_adv)]
 pub fn ext_adv_start(instance: u8) -> Result<(), BleError> {
     let rc = unsafe { ble_gap_ext_adv_start(instance, 0, 0) };
     if rc == BLE_HS_EALREADY as c_int {
@@ -257,6 +340,7 @@ pub fn ext_adv_start(instance: u8) -> Result<(), BleError> {
     BleError::from_raw(rc)
 }
 
+#[cfg(esp_idf_bt_nimble_ext_adv)]
 pub fn ext_adv_stop(instance: u8) -> Result<(), BleError> {
     BleError::from_raw(unsafe { ble_gap_ext_adv_stop(instance) })
 }

--- a/src/ble/gap.rs
+++ b/src/ble/gap.rs
@@ -311,6 +311,7 @@ pub fn ext_adv_set_addr(instance: u8, addr: &BleAddr) -> Result<(), BleError> {
 pub fn ext_adv_set_data(instance: u8, data: &[u8]) -> Result<(), BleError> {
     let om = super::mbuf::mbuf_from_slice(data)?;
 
+    // `ble_gap_ext_adv_set_data` takes ownership of `om` and frees it on all paths (no leak, no double-free).
     BleError::from_raw(unsafe { ble_gap_ext_adv_set_data(instance, om) })
 }
 

--- a/src/ble/gap.rs
+++ b/src/ble/gap.rs
@@ -19,8 +19,6 @@ pub fn svc_set_device_name(name: &str) -> Result<(), BleError> {
     BleError::from_raw(unsafe { ble_svc_gap_device_name_set(name.as_ptr()) })
 }
 
-
-
 // Advertising. Drive these from an `on_sync` closure once the host has synced,
 // and restart from an `on_gap_event` disconnect handler.
 //

--- a/src/ble/gatt.rs
+++ b/src/ble/gatt.rs
@@ -1,0 +1,53 @@
+//! NimBLE GATT: shared types and helpers.
+
+use core::ffi::c_int;
+
+use enumset::{EnumSet, EnumSetType};
+
+use crate::sys::*;
+
+use super::BleError;
+
+pub mod gatts;
+
+/// A GATT attribute handle (e.g. a characteristic's value handle).
+pub type Handle = u16;
+
+/// Set the preferred ATT MTU. Safe to call before or after the host starts.
+pub fn set_preferred_mtu(mtu: u16) -> Result<(), BleError> {
+    BleError::from_raw(unsafe { ble_att_set_preferred_mtu(mtu) })
+}
+
+/// The negotiated ATT MTU for a connection
+pub fn att_mtu(conn_handle: gatts::ConnectionId) -> Result<u16, BleError> {
+    match unsafe { ble_att_mtu(conn_handle) } {
+        0 => Err(BleError::new(BLE_HS_ENOTCONN as c_int)),
+        mtu => Ok(mtu),
+    }
+}
+
+/// A GATT characteristic operation flag (`BLE_GATT_CHR_F_*`).
+#[derive(Debug, EnumSetType)]
+pub enum BleGattCharFlag {
+    Read,
+    Write,
+    Notify,
+    Indicate,
+}
+
+impl From<BleGattCharFlag> for ble_gatt_chr_flags {
+    fn from(flag: BleGattCharFlag) -> Self {
+        match flag {
+            BleGattCharFlag::Read => BLE_GATT_CHR_F_READ,
+            BleGattCharFlag::Write => BLE_GATT_CHR_F_WRITE,
+            BleGattCharFlag::Notify => BLE_GATT_CHR_F_NOTIFY,
+            BleGattCharFlag::Indicate => BLE_GATT_CHR_F_INDICATE,
+        }
+    }
+}
+
+pub(crate) fn flags_to_repr(flags: EnumSet<BleGattCharFlag>) -> ble_gatt_chr_flags {
+    flags
+        .iter()
+        .fold(0, |acc, flag| acc | ble_gatt_chr_flags::from(flag))
+}

--- a/src/ble/gatt/gatts.rs
+++ b/src/ble/gatt/gatts.rs
@@ -1,0 +1,213 @@
+//! NimBLE GATT server: service registration and per-characteristic access.
+
+use core::ffi::{c_int, c_void};
+use core::ptr;
+use core::sync::atomic::AtomicU16;
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
+use enumset::EnumSet;
+
+use crate::sys::*;
+
+use super::super::mbuf::{mbuf_from_slice, Mbuf};
+use super::super::{BleError, BleSetup, BleUuid};
+use super::{flags_to_repr, BleGattCharFlag, Handle};
+
+pub type ConnectionId = u16;
+
+type AccessClosure<'ble> = dyn FnMut(BleGattAccess) -> i32 + Send + 'ble;
+
+pub enum BleGattAccess<'a> {
+    Read {
+        conn_handle: ConnectionId,
+        attr_handle: Handle,
+        reply: Mbuf<'a>,
+    },
+    Write {
+        conn_handle: ConnectionId,
+        attr_handle: Handle,
+        data: Mbuf<'a>,
+    },
+}
+
+unsafe extern "C" fn access_trampoline(
+    conn_handle: u16,
+    attr_handle: u16,
+    ctxt: *mut ble_gatt_access_ctxt,
+    arg: *mut c_void,
+) -> c_int {
+    // `arg` is the thin pointer to the characteristic's boxed closure; the
+    // laundered lifetime is sound because the closure lives for `'ble`, which
+    // outlives the host.
+    let closure: &mut AccessClosure = unsafe { &mut **(arg as *mut Box<AccessClosure>) };
+
+    let mbuf = Mbuf::from_raw(unsafe { (*ctxt).om });
+
+    let rc = match unsafe { (*ctxt).op } as u32 {
+        BLE_GATT_ACCESS_OP_READ_CHR => closure(BleGattAccess::Read {
+            conn_handle,
+            attr_handle,
+            reply: mbuf,
+        }),
+        BLE_GATT_ACCESS_OP_WRITE_CHR => closure(BleGattAccess::Write {
+            conn_handle,
+            attr_handle,
+            data: mbuf,
+        }),
+        _ => BLE_ATT_ERR_UNLIKELY as i32,
+    };
+
+    rc as c_int
+}
+
+/// A characteristic in a [`BleGattService`]. `val_handle` is a caller-owned slot
+/// NimBLE fills with the value attribute handle during registration; `access`
+/// is invoked on the host task for every read and write.
+pub struct BleGattCharacteristic<'ble> {
+    uuid: BleUuid,
+    flags: EnumSet<BleGattCharFlag>,
+    val_handle: &'ble AtomicU16,
+    access: Box<AccessClosure<'ble>>,
+}
+
+impl<'ble> BleGattCharacteristic<'ble> {
+    pub fn new<F>(
+        uuid: BleUuid,
+        flags: EnumSet<BleGattCharFlag>,
+        val_handle: &'ble AtomicU16,
+        access: F,
+    ) -> Self
+    where
+        F: FnMut(BleGattAccess) -> i32 + Send + 'ble,
+    {
+        Self {
+            uuid,
+            flags,
+            val_handle,
+            access: Box::new(access),
+        }
+    }
+}
+
+/// A GATT service definition.
+pub struct BleGattService<'ble> {
+    primary: bool,
+    uuid: BleUuid,
+    characteristics: Vec<BleGattCharacteristic<'ble>>,
+}
+
+impl<'ble> BleGattService<'ble> {
+    pub fn new(
+        primary: bool,
+        uuid: BleUuid,
+        characteristics: Vec<BleGattCharacteristic<'ble>>,
+    ) -> Self {
+        Self {
+            primary,
+            uuid,
+            characteristics,
+        }
+    }
+}
+
+/// This defines GATT services as a tree structure. You allocate this
+/// and let the BLE stack borrow it. You can add callbacks to handle reads/writes, and,
+/// once the stack is started, use the val_handle references on BleGattCharacteristic to
+/// access the value slots the BLE stack will set up.
+pub struct BleGattServices<'ble> {
+    // There are dragons here. The overall structure combines safe Rust types with the
+    // c-level service definitions NimBLE expects. The structure is self-referential, so
+    // it's critical that any pointers in svc_defs and _chr_defs go to locations that are
+    // stable even if the BleGattServices structure moves (eg. Boxed places).
+    _services: Vec<BleGattService<'ble>>,
+    _chr_defs: Vec<Box<[ble_gatt_chr_def]>>,
+    svc_defs: Box<[ble_gatt_svc_def]>,
+}
+
+impl<'ble> BleGattServices<'ble> {
+    pub fn new(mut services: Vec<BleGattService<'ble>>) -> Self {
+        let mut chr_storage: Vec<Box<[ble_gatt_chr_def]>> = Vec::with_capacity(services.len());
+        let mut svc_defs: Vec<ble_gatt_svc_def> = Vec::with_capacity(services.len() + 1);
+
+        // Build the C def arrays with pointers into `services`; it is moved into
+        // `self` afterwards, which relocates only the Vec handle, not the
+        // heap-allocated elements the pointers target.
+        for service in &mut services {
+            let mut chr_defs: Vec<ble_gatt_chr_def> =
+                Vec::with_capacity(service.characteristics.len() + 1);
+
+            for chr in &mut service.characteristics {
+                let uuid = chr.uuid.as_ptr();
+                let flags = flags_to_repr(chr.flags);
+                let val_handle = chr.val_handle.as_ptr();
+                let arg = &mut chr.access as *mut Box<AccessClosure<'ble>> as *mut c_void;
+
+                chr_defs.push(ble_gatt_chr_def {
+                    uuid,
+                    access_cb: Some(access_trampoline),
+                    arg,
+                    flags,
+                    val_handle,
+                    ..Default::default()
+                });
+            }
+            chr_defs.push(ble_gatt_chr_def::default());
+
+            let chr_defs = chr_defs.into_boxed_slice();
+            let chr_ptr = chr_defs.as_ptr();
+            chr_storage.push(chr_defs);
+
+            svc_defs.push(ble_gatt_svc_def {
+                type_: if service.primary {
+                    BLE_GATT_SVC_TYPE_PRIMARY as u8
+                } else {
+                    BLE_GATT_SVC_TYPE_SECONDARY as u8
+                },
+                uuid: service.uuid.as_ptr(),
+                includes: ptr::null_mut(),
+                characteristics: chr_ptr,
+            });
+        }
+        svc_defs.push(ble_gatt_svc_def::default());
+
+        Self {
+            _services: services,
+            _chr_defs: chr_storage,
+            svc_defs: svc_defs.into_boxed_slice(),
+        }
+    }
+}
+
+/// GATT-server setup routines, mapping to the ble_gatts_* family of NimBLE functions;
+/// this is available while you have a BleSetup instance, so before you've called start.
+pub struct GattsSetup<'a, 'ble> {
+    _setup: &'a mut BleSetup<'ble>,
+}
+
+impl<'a, 'ble> GattsSetup<'a, 'ble> {
+    pub fn new(setup: &'a mut BleSetup<'ble>) -> Self {
+        Self { _setup: setup }
+    }
+
+    /// Queue `services` to be registered once BleSetup#start() is called.
+    pub fn add_services(&mut self, services: &'ble BleGattServices<'ble>) -> Result<(), BleError> {
+        let svc_defs = services.svc_defs.as_ptr();
+
+        BleError::from_raw(unsafe { ble_gatts_count_cfg(svc_defs) })?;
+        BleError::from_raw(unsafe { ble_gatts_add_svcs(svc_defs) })
+    }
+}
+
+/// Sends a "free-form" characteristic indication.
+pub fn indicate(
+    conn_handle: ConnectionId,
+    val_handle: Handle,
+    data: &[u8],
+) -> Result<(), BleError> {
+    let om = mbuf_from_slice(data)?;
+
+    // No cleanup of om, ble_gatts_indicate_custom takes ownership
+    BleError::from_raw(unsafe { ble_gatts_indicate_custom(conn_handle, val_handle, om) })
+}

--- a/src/ble/gatt/gatts.rs
+++ b/src/ble/gatt/gatts.rs
@@ -2,7 +2,6 @@
 
 use core::ffi::{c_int, c_void};
 use core::ptr;
-use core::sync::atomic::AtomicU16;
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
@@ -62,30 +61,76 @@ unsafe extern "C" fn access_trampoline(
     rc as c_int
 }
 
-/// A characteristic in a [`BleGattService`]. `val_handle` is a caller-owned slot
-/// NimBLE fills with the value attribute handle during registration; `access`
-/// is invoked on the host task for every read and write.
+/// A GATT registration event, delivered on the host task via
+/// [`BleSetup::on_gatts_register`](super::super::BleSetup::on_gatts_register) as the
+/// service table is registered. This is how you learn the attribute handles NimBLE
+/// assigns; capture the value handles you need (matching on `uuid`) here.
+pub enum BleGattRegister {
+    Service {
+        uuid: BleUuid,
+        handle: Handle,
+    },
+    Characteristic {
+        uuid: BleUuid,
+        def_handle: Handle,
+        val_handle: Handle,
+    },
+    Descriptor {
+        uuid: BleUuid,
+        handle: Handle,
+    },
+    Other,
+}
+
+impl From<&ble_gatt_register_ctxt> for BleGattRegister {
+    fn from(ctxt: &ble_gatt_register_ctxt) -> Self {
+        let anon = &ctxt.__bindgen_anon_1;
+
+        match ctxt.op as u32 {
+            BLE_GATT_REGISTER_OP_SVC => {
+                let svc = unsafe { &anon.svc };
+                Self::Service {
+                    uuid: unsafe { BleUuid::from_raw((*svc.svc_def).uuid) },
+                    handle: svc.handle,
+                }
+            }
+            BLE_GATT_REGISTER_OP_CHR => {
+                let chr = unsafe { &anon.chr };
+                Self::Characteristic {
+                    uuid: unsafe { BleUuid::from_raw((*chr.chr_def).uuid) },
+                    def_handle: chr.def_handle,
+                    val_handle: chr.val_handle,
+                }
+            }
+            BLE_GATT_REGISTER_OP_DSC => {
+                let dsc = unsafe { &anon.dsc };
+                Self::Descriptor {
+                    uuid: unsafe { BleUuid::from_raw((*dsc.dsc_def).uuid) },
+                    handle: dsc.handle,
+                }
+            }
+            _ => Self::Other,
+        }
+    }
+}
+
+/// A characteristic in a [`BleGattService`]. `access` is invoked on the host task
+/// for every read and write; the value attribute handle NimBLE assigns is reported
+/// via [`BleGattRegister`] during registration.
 pub struct BleGattCharacteristic<'ble> {
     uuid: BleUuid,
     flags: EnumSet<BleGattCharFlag>,
-    val_handle: &'ble AtomicU16,
     access: Box<AccessClosure<'ble>>,
 }
 
 impl<'ble> BleGattCharacteristic<'ble> {
-    pub fn new<F>(
-        uuid: BleUuid,
-        flags: EnumSet<BleGattCharFlag>,
-        val_handle: &'ble AtomicU16,
-        access: F,
-    ) -> Self
+    pub fn new<F>(uuid: BleUuid, flags: EnumSet<BleGattCharFlag>, access: F) -> Self
     where
         F: FnMut(BleGattAccess) -> i32 + Send + 'ble,
     {
         Self {
             uuid,
             flags,
-            val_handle,
             access: Box::new(access),
         }
     }
@@ -114,8 +159,8 @@ impl<'ble> BleGattService<'ble> {
 
 /// This defines GATT services as a tree structure. You allocate this
 /// and let the BLE stack borrow it. You can add callbacks to handle reads/writes, and,
-/// once the stack is started, use the val_handle references on BleGattCharacteristic to
-/// access the value slots the BLE stack will set up.
+/// once the stack is started, learn the attribute handles the BLE stack assigns via
+/// [`BleSetup::on_gatts_register`](super::super::BleSetup::on_gatts_register).
 pub struct BleGattServices<'ble> {
     // There are dragons here. The overall structure combines safe Rust types with the
     // c-level service definitions NimBLE expects. The structure is self-referential, so
@@ -141,15 +186,17 @@ impl<'ble> BleGattServices<'ble> {
             for chr in &mut service.characteristics {
                 let uuid = chr.uuid.as_ptr();
                 let flags = flags_to_repr(chr.flags);
-                let val_handle = chr.val_handle.as_ptr();
                 let arg = &mut chr.access as *mut Box<AccessClosure<'ble>> as *mut c_void;
 
+                // `val_handle` is left null: handles are reported via `BleGattRegister`
+                // rather than written back through a caller-owned pointer, because I wasn't
+                // able to think up a safe API for the in-tree val_handles.
                 chr_defs.push(ble_gatt_chr_def {
                     uuid,
                     access_cb: Some(access_trampoline),
                     arg,
                     flags,
-                    val_handle,
+                    val_handle: ptr::null_mut(),
                     ..Default::default()
                 });
             }

--- a/src/ble/gatt/gatts.rs
+++ b/src/ble/gatt/gatts.rs
@@ -255,6 +255,6 @@ pub fn indicate(
 ) -> Result<(), BleError> {
     let om = mbuf_from_slice(data)?;
 
-    // No cleanup of om, ble_gatts_indicate_custom takes ownership
+    // `ble_gatts_indicate_custom` takes ownership of `om` and frees it on all paths (no leak, no double-free).
     BleError::from_raw(unsafe { ble_gatts_indicate_custom(conn_handle, val_handle, om) })
 }

--- a/src/ble/mbuf.rs
+++ b/src/ble/mbuf.rs
@@ -1,0 +1,58 @@
+//! Safe interaction with the NimBLE os_mbuf buffer system
+
+use core::ffi::{c_int, c_void};
+use core::marker::PhantomData;
+
+use crate::sys::*;
+
+use super::BleError;
+
+/// View of an os_mbuf, the data buffers used by NimBLE
+pub struct Mbuf<'a> {
+    om: *mut os_mbuf,
+    _p: PhantomData<&'a mut os_mbuf>,
+}
+
+impl Mbuf<'_> {
+    pub(crate) fn from_raw(om: *mut os_mbuf) -> Self {
+        Self {
+            om,
+            _p: PhantomData,
+        }
+    }
+
+    /// Copy this Mbuf into `buf`, returning the number of bytes copied or error if buf is too small
+    pub fn read(&self, buf: &mut [u8]) -> Result<usize, BleError> {
+        let mut copied: u16 = 0;
+
+        BleError::from_raw(unsafe {
+            ble_hs_mbuf_to_flat(
+                self.om,
+                buf.as_mut_ptr() as *mut c_void,
+                buf.len() as u16,
+                &mut copied,
+            )
+        })?;
+
+        Ok(copied as usize)
+    }
+
+    /// Append `buf` to the mbuf.
+    pub fn append(&mut self, buf: &[u8]) -> Result<(), BleError> {
+        BleError::from_raw(unsafe {
+            r_os_mbuf_append(self.om, buf.as_ptr() as *const c_void, buf.len() as u16)
+        })
+    }
+}
+
+/// Allocate an `os_mbuf` and copy `buf` into it. Errors with `BLE_HS_ENOMEM` if
+/// allocation fails.
+pub(crate) fn mbuf_from_slice(buf: &[u8]) -> Result<*mut os_mbuf, BleError> {
+    let om = unsafe { ble_hs_mbuf_from_flat(buf.as_ptr() as *const c_void, buf.len() as u16) };
+
+    if om.is_null() {
+        Err(BleError::new(BLE_HS_ENOMEM as c_int))
+    } else {
+        Ok(om)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,13 @@ extern crate alloc;
 #[cfg(all(
     not(any(esp32s2, esp32p4)),
     esp_idf_bt_enabled,
+    esp_idf_bt_nimble_enabled,
+    feature = "alloc",
+))]
+pub mod ble;
+#[cfg(all(
+    not(any(esp32s2, esp32p4)),
+    esp_idf_bt_enabled,
     esp_idf_bt_bluedroid_enabled,
     feature = "alloc",
 ))]


### PR DESCRIPTION
### Submission Checklist 📝

- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section. 

(Have not added CHANGELOG entry yet, happy to do that if we can get the PR to a point where there's agreement this PR is good enough to be merged)

### Pull Request Details 📖

#### Description

An initial stab of a *partial* safe wrapper for the light-weight NimBLE stack, as discussed with @ivmarkov in the rs-matter Matrix chat. This adds enough for a working GATT Server; I've confirmed the example runs and works on an ESP32-C5. 

_Disclosure_: 

(1) I'm very much not an expert in BLE or NimBLE; my use case here is for the provisioning portion of Matter. This is prep-work for upstreaming a vendored patch I'm carrying for https://github.com/sysgrok/esp-idf-matter to use NimBLE there instead of Bluedroid, in order to make rs-matter work on the ESP32-C5. 

(2) I've used Claude code while writing this changeset, though the design and structure of the patch is my own and the code has been *thoroughly* manually reviewed in several iterations and, as noted above, has been tested to work on real hardware. 

Super open to feedback here in any way to make the patch palatable for the maintainer team. I've tried to strike a balance between matching the underlying API structure of NimBLE (which is quite different form Bluedroids), while aligning with the existing shape of the repo APIs.

#### Commit message

ESP-IDF ships two bluetooth stacks, one based on Bluedroid and one based on NimBLE. Bluedroid provides a complete "real" Bluetooth stack, while NimBLE provides only BLE but does it with lower resource use.

This adds an *incomplete* and *early* safe wrapper for the NimBLE stack, just enough to implement a bare-bones BLE GATT server.

The overall structure tries to find a good balance between providing a safe API on top of normal NimBLE routines, without completely diverging from the structure already established by the Bluedroid wrapper.

The two APIs are very different, so the new wrapper is built side-by-side, giving this repo `bt.rs` for full bluetooth via Bluedroid and `ble.rs` for light-weight BLE via NimBLE.

Structure:

```
src/
  ble.rs # top-level entrypoint
  ble/gap.rs # GAP stuff, wraps ble_gap_XXX and ble_svc_gap_XXX routines
  ble/gatt.rs # GATT stuff shared between clients (not implemented) and servers
  ble/gatt/gatts.rs # wraps ble_gatts_XXX
  ble/mbus.rs # wrappers for NimBLEs buffer pool
```

For GATT servers, NimBLE takes a tree structure of attributes and callback pointers. The proposed API here mirrors that approach, expecting users to allocate and provide a reference to an equivalent Rust structure - note there's quite a bit of dragons there as this ends up being a self-referential structure we give to the NimBLE stack.. I think the way I've structured it now is safe from moves while the ble stack is running but could definintely use some critical eyes.

#### Testing

I built the example, flashed it to an ESP32-C5 and then verified that my laptop's BLE stack could discover and interact with it.